### PR TITLE
Extracting Build ID

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: go
+go:
+  - "1.13.x"
 
 os:
   - linux

--- a/buildid.go
+++ b/buildid.go
@@ -1,0 +1,59 @@
+// Copyright 2019 The GoRE.tk Authors. All rights reserved.
+// Use of this source code is governed by the license that
+// can be found in the LICENSE file.
+
+package gore
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+var (
+	goNoteNameELF  = []byte("Go\x00\x00")
+	goNoteRawStart = []byte("\xff Go build ID: \"")
+	goNoteRawEnd   = []byte("\"\n \xff")
+)
+
+func parseBuildIDFromElf(data []byte, byteOrder binary.ByteOrder) (string, error) {
+	r := bytes.NewReader(data)
+	var nameLen uint32
+	var idLen uint32
+	var tag uint32
+	err := binary.Read(r, byteOrder, &nameLen)
+	if err != nil {
+		return "", fmt.Errorf("Error when reading the BuildID name length: %w", err)
+	}
+	err = binary.Read(r, byteOrder, &idLen)
+	if err != nil {
+		return "", fmt.Errorf("Error when reading the BuildID ID length: %w", err)
+	}
+	err = binary.Read(r, byteOrder, &tag)
+	if err != nil {
+		return "", fmt.Errorf("Error when reading the BuildID tag: %w", err)
+	}
+
+	if tag != uint32(4) {
+		return "", fmt.Errorf("build ID does not match expected value. 0x%x parsed", tag)
+	}
+
+	noteName := data[12 : 12+int(nameLen)]
+	if !bytes.Equal(noteName, goNoteNameELF) {
+		return "", fmt.Errorf("note name not as expected")
+	}
+	return string(data[16 : 16+int(idLen)]), nil
+}
+
+func parseBuildIDFromRaw(data []byte) (string, error) {
+	idx := bytes.Index(data, goNoteRawStart)
+	if idx < 0 {
+		// No Build ID
+		return "", nil
+	}
+	end := bytes.Index(data, goNoteRawEnd)
+	if end < 0 {
+		return "", fmt.Errorf("malformed Build ID")
+	}
+	return string(data[idx+len(goNoteRawStart) : end]), nil
+}

--- a/buildid_test.go
+++ b/buildid_test.go
@@ -1,0 +1,48 @@
+// Copyright 2019 The GoRE.tk Authors. All rights reserved.
+// Use of this source code is governed by the license that
+// can be found in the LICENSE file.
+
+package gore
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseBuildIDElf(t *testing.T) {
+	assert := assert.New(t)
+	expectedID := "DrtsigZmOidE-wfbFVNF/io-X8KB-ByimyyODdYUe/Z7tIlu8GbOwt0Jup-Hji/fofocVx5sk8UpaKMTx0a"
+	tag := uint32(4)
+	gonote := []byte("Go\x00\x00")
+	nameSize := uint32(4)
+
+	buf := &bytes.Buffer{}
+
+	binary.Write(buf, binary.LittleEndian, nameSize)
+	binary.Write(buf, binary.LittleEndian, uint32(len(expectedID)))
+	binary.Write(buf, binary.LittleEndian, tag)
+	buf.Write(gonote)
+	buf.Write([]byte(expectedID))
+
+	actual, err := parseBuildIDFromElf(buf.Bytes(), binary.LittleEndian)
+	assert.NoError(err, "Parsing the note should not fail.")
+	assert.Equal(expectedID, actual, "Extracted ID does not match.")
+}
+
+func TestParseBuildIDRaw(t *testing.T) {
+	assert := assert.New(t)
+	expectedID := "DrtsigZmOidE-wfbFVNF/io-X8KB-ByimyyODdYUe/Z7tIlu8GbOwt0Jup-Hji/fofocVx5sk8UpaKMTx0a"
+
+	buf := &bytes.Buffer{}
+	buf.Write(goNoteRawStart)
+	buf.Write([]byte(expectedID))
+	buf.Write(goNoteRawEnd)
+	buf.Write([]byte{0xcc, 0xcc, 0xcc, 0xcc})
+
+	actual, err := parseBuildIDFromRaw(buf.Bytes())
+	assert.NoError(err, "Parsing the note should not fail.")
+	assert.Equal(expectedID, actual, "Extracted ID does not match.")
+}

--- a/elf.go
+++ b/elf.go
@@ -7,6 +7,7 @@ package gore
 import (
 	"debug/elf"
 	"debug/gosym"
+	"fmt"
 )
 
 func openELF(fp string) (*elfFile, error) {
@@ -91,4 +92,12 @@ func (e *elfFile) getFileInfo() *FileInfo {
 		OS:        e.file.Machine.String(),
 		WordSize:  wordSize,
 	}
+}
+
+func (e *elfFile) getBuildID() (string, error) {
+	_, data, err := e.getSectionData(".note.go.buildid")
+	if err != nil {
+		return "", fmt.Errorf("error when getting note section %w", err)
+	}
+	return parseBuildIDFromElf(data, e.file.ByteOrder)
 }

--- a/file.go
+++ b/file.go
@@ -71,12 +71,19 @@ func Open(filePath string) (*GoFile, error) {
 		return nil, ErrUnsupportedFile
 	}
 	gofile.FileInfo = gofile.fh.getFileInfo()
-	return gofile, nil
+
+	buildID, err := gofile.fh.getBuildID()
+	gofile.BuildID = buildID
+
+	return gofile, err
 }
 
 // GoFile is a structure representing a go binary file.
 type GoFile struct {
-	FileInfo     *FileInfo
+	// FileInfo holds information about the file.
+	FileInfo *FileInfo
+	// BuildID is the Go build ID hash extracted from the binary.
+	BuildID      string
 	fh           fileHandler
 	stdPkgs      []*Package
 	pkgs         []*Package
@@ -298,6 +305,7 @@ type fileHandler interface {
 	getFileInfo() *FileInfo
 	getPCLNTABData() (uint64, []byte, error)
 	moduledataSection() string
+	getBuildID() (string, error)
 }
 
 func fileMagicMatch(buf, magic []byte) bool {

--- a/macho.go
+++ b/macho.go
@@ -3,6 +3,7 @@ package gore
 import (
 	"debug/gosym"
 	"debug/macho"
+	"fmt"
 )
 
 func openMachO(fp string) (*machoFile, error) {
@@ -86,4 +87,12 @@ func (m *machoFile) getPCLNTABData() (uint64, []byte, error) {
 
 func (m *machoFile) moduledataSection() string {
 	return "__noptrdata"
+}
+
+func (m *machoFile) getBuildID() (string, error) {
+	data, err := m.getCodeSection()
+	if err != nil {
+		return "", fmt.Errorf("failed to get code section: %w", err)
+	}
+	return parseBuildIDFromRaw(data)
 }

--- a/pe.go
+++ b/pe.go
@@ -8,6 +8,7 @@ import (
 	"debug/gosym"
 	"debug/pe"
 	"encoding/binary"
+	"fmt"
 )
 
 func openPE(fp string) (*peFile, error) {
@@ -94,4 +95,12 @@ func (p *peFile) getFileInfo() *FileInfo {
 		p.imageBase = optHdr.ImageBase
 	}
 	return fi
+}
+
+func (p *peFile) getBuildID() (string, error) {
+	data, err := p.getCodeSection()
+	if err != nil {
+		return "", fmt.Errorf("failed to get code section: %w", err)
+	}
+	return parseBuildIDFromRaw(data)
 }


### PR DESCRIPTION
Add functionality to extract the Build ID stored in the file. The ID is stored as an attribute of the GoFile. #7 