### PR TITLE
Improve Go compiler version detection

### DIFF
--- a/elf.go
+++ b/elf.go
@@ -87,10 +87,24 @@ func (e *elfFile) getFileInfo() *FileInfo {
 	if class == elf.ELFCLASS64 {
 		wordSize = intSize64
 	}
+
+	var arch string
+	switch e.file.Machine {
+	case elf.EM_386:
+		arch = Arch386
+	case elf.EM_MIPS:
+		arch = ArchMIPS
+	case elf.EM_X86_64:
+		arch = ArchAMD64
+	case elf.EM_ARM:
+		arch = ArchARM
+	}
+
 	return &FileInfo{
 		ByteOrder: e.file.FileHeader.ByteOrder,
 		OS:        e.file.Machine.String(),
 		WordSize:  wordSize,
+		Arch:      arch,
 	}
 }
 

--- a/file.go
+++ b/file.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"debug/gosym"
 	"encoding/binary"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -275,6 +276,11 @@ func (f *GoFile) Bytes(address uint64, length uint64) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if address+length-base > uint64(len(section)) {
+		return nil, errors.New("length out of bounds")
+	}
+
 	return section[address-base : address+length-base], nil
 }
 
@@ -314,6 +320,8 @@ func fileMagicMatch(buf, magic []byte) bool {
 
 // FileInfo holds information about the file.
 type FileInfo struct {
+	// Arch is the architecture the binary is compiled for.
+	Arch string
 	// OS is the operating system the binary is compiled for.
 	OS string
 	// ByteOrder is the byte order.
@@ -322,3 +330,10 @@ type FileInfo struct {
 	WordSize  int
 	goversion *GoVersion
 }
+
+const (
+	ArchAMD64 = "amd64"
+	ArchARM   = "arm"
+	Arch386   = "i386"
+	ArchMIPS  = "mips"
+)

--- a/file_test.go
+++ b/file_test.go
@@ -130,7 +130,16 @@ func TestGetPackages(t *testing.T) {
 }
 
 func TestGetCompilerVersion(t *testing.T) {
-	expectedVersion := ResolveGoVersion(testCompilerVersion())
+	testVersion := testCompilerVersion()
+	expectedVersion := ResolveGoVersion(testVersion)
+
+	// If the version could not be resolved, the version is new
+	// and the library doesn't know about it. Use the version string
+	// to created a new version.
+	if expectedVersion == nil {
+		expectedVersion = &GoVersion{Name: testVersion}
+	}
+
 	for _, test := range dynResources {
 		t.Run("parsing_"+test.os+"-"+test.arch, func(t *testing.T) {
 			t.Parallel()

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/goretk/gore
 
 go 1.13
 
-require github.com/stretchr/testify v1.4.0
+require (
+	github.com/stretchr/testify v1.4.0
+	golang.org/x/arch v0.0.0-20201207233722-1e68675e650f
+)

--- a/go.sum
+++ b/go.sum
@@ -5,7 +5,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+golang.org/x/arch v0.0.0-20201207233722-1e68675e650f h1:Ow3NJjUYI2Fg1drjGoEXxY9k2WmOm+CRZo9n0ofmf5s=
+golang.org/x/arch v0.0.0-20201207233722-1e68675e650f/go.mod h1:flIaEI6LNU6xOCD5PaJvn9wGP0agmIOqjrtsKGRguv4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/goversion.go
+++ b/goversion.go
@@ -261,7 +261,7 @@ pkgLoop:
 
 	// Check if the functions was found
 	if fcn == nil {
-		// TODO: return an error type.
+		// If we can't find the function there is nothing to do.
 		return nil
 	}
 
@@ -282,6 +282,8 @@ pkgLoop:
 	for s < len(buf) {
 		inst, err := x86asm.Decode(buf[s:], mode)
 		if err != nil {
+			// If we fail to decode the instruction, something is wrong so
+			// bailout.
 			return nil
 		}
 
@@ -318,11 +320,13 @@ pkgLoop:
 		r := bytes.NewReader(b)
 		ptr, err := readUIntTo64(r, f.FileInfo.ByteOrder, is32)
 		if err != nil {
-			return nil
+			// Probably not the right instruction, so go to next.
+			continue
 		}
 		l, err := readUIntTo64(r, f.FileInfo.ByteOrder, is32)
 		if err != nil {
-			return nil
+			// Probably not the right instruction, so go to next.
+			continue
 		}
 
 		bstr, _ := f.Bytes(ptr, l)

--- a/goversion.go
+++ b/goversion.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"golang.org/x/arch/x86/x86asm"
 )
 
 var goVersionMatcher = regexp.MustCompile(`(go[\d+\.]*(beta|rc)?[\d*])`)
@@ -182,6 +184,14 @@ func GoVersionCompare(a, b string) int {
 }
 
 func findGoCompilerVersion(f *GoFile) (*GoVersion, error) {
+	// Try to determine the version based on the schedinit function.
+	if v := tryFromSchedInit(f); v != nil {
+		return v, nil
+	}
+
+	// If no version was found, search the sections for the
+	// version string.
+
 	data, err := f.fh.getRData()
 	// If read only data section does not exist, try text.
 	if err == ErrSectionDoesNotExist {
@@ -211,6 +221,132 @@ func findGoCompilerVersion(f *GoFile) (*GoVersion, error) {
 		return ver, nil
 	}
 	return nil, nil
+}
+
+// tryFromSchedInit tries to identify the version of the Go compiler that compiled the code.
+// The function "schedinit" in the "runtime" package has the only reference to this string
+// used to identify the version.
+// The function returns nil if no version is found.
+func tryFromSchedInit(f *GoFile) *GoVersion {
+	// Check for non supported architectures.
+	if f.FileInfo.Arch != Arch386 && f.FileInfo.Arch != ArchAMD64 {
+		return nil
+	}
+
+	is32 := false
+	if f.FileInfo.Arch == Arch386 {
+		is32 = true
+	}
+
+	// Find shedinit function.
+	var fcn *Function
+	std, err := f.GetSTDLib()
+	if err != nil {
+		return nil
+	}
+
+pkgLoop:
+	for _, v := range std {
+		if v.Name != "runtime" {
+			continue
+		}
+		for _, vv := range v.Functions {
+			if vv.Name != "schedinit" {
+				continue
+			}
+			fcn = vv
+			break pkgLoop
+		}
+	}
+
+	// Check if the functions was found
+	if fcn == nil {
+		// TODO: return an error type.
+		return nil
+	}
+
+	// Get the raw hex.
+	buf, err := f.Bytes(fcn.Offset, fcn.End-fcn.Offset)
+	if err != nil {
+		return nil
+	}
+
+	/*
+		Disassemble the function until the loading of the Go version is found.
+	*/
+
+	// Counter for how many bytes has been read.
+	s := 0
+	mode := f.FileInfo.WordSize * 8
+
+	for s < len(buf) {
+		inst, err := x86asm.Decode(buf[s:], mode)
+		if err != nil {
+			return nil
+		}
+
+		// Update next instruction location.
+		s = s + inst.Len
+
+		// Check if it's a "lea" instruction.
+		if inst.Op != x86asm.LEA {
+			continue
+		}
+
+		// Check what it's loading and if it's pointing to the compiler version used.
+		// First assume that the address is a direct addressing.
+		arg := inst.Args[1].(x86asm.Mem)
+		addr := arg.Disp
+		if arg.Base == x86asm.EIP || arg.Base == x86asm.RIP {
+			// If the addressing is based on the instruction pointer, fix the address.
+			addr = addr + int64(fcn.Offset) + int64(s)
+		}
+
+		// If the addressing is based on the stack pointer, this is not the right
+		// instruction.
+		if arg.Base == x86asm.ESP || arg.Base == x86asm.RSP {
+			continue
+		}
+
+		// Resolve the pointer to the string. If we get no data, this is not the
+		// right instruction.
+		b, _ := f.Bytes(uint64(addr), uint64(0x20))
+		if b == nil {
+			continue
+		}
+
+		r := bytes.NewReader(b)
+		ptr, err := readUIntTo64(r, f.FileInfo.ByteOrder, is32)
+		if err != nil {
+			return nil
+		}
+		l, err := readUIntTo64(r, f.FileInfo.ByteOrder, is32)
+		if err != nil {
+			return nil
+		}
+
+		bstr, _ := f.Bytes(ptr, l)
+		if bstr == nil {
+			continue
+		}
+
+		if !bytes.HasPrefix(bstr, []byte("go1.")) {
+			continue
+		}
+
+		// Likely the version string.
+		ver := string(bstr)
+
+		gover := ResolveGoVersion(ver)
+		if gover != nil {
+			return gover
+		}
+
+		// An unknown version.
+		return &GoVersion{Name: ver}
+	}
+
+	return nil
 }
 
 func matchGoVersionString(data []byte) string {

--- a/goversion_test.go
+++ b/goversion_test.go
@@ -6,9 +6,11 @@ package gore
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolvingVersionFromTag(t *testing.T) {
@@ -84,6 +86,86 @@ func TestVersionComparer(t *testing.T) {
 		t.Run(fmt.Sprintf("Testing case %d", i+1), func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(test.val, GoVersionCompare(test.a, test.b), fmt.Sprintf("Case %d failed", i+1))
+		})
+	}
+}
+
+func TestExtractVersionFromInitSched(t *testing.T) {
+	r := require.New(t)
+
+	tests := []struct {
+		f       string
+		version string
+	}{
+		{"gold-linux-amd64-1.15.0", "go1.15"},
+		{"gold-linux-386-1.15.0", "go1.15"},
+		{"gold-windows-amd64-1.15.0", "go1.15"},
+		{"gold-windows-386-1.15.0", "go1.15"},
+		{"gold-darwin-amd64-1.15.0", "go1.15"},
+
+		{"gold-linux-amd64-1.14.0", "go1.14"},
+		{"gold-linux-386-1.14.0", "go1.14"},
+		{"gold-windows-amd64-1.14.0", "go1.14"},
+		{"gold-windows-386-1.14.0", "go1.14"},
+		{"gold-darwin-amd64-1.14.0", "go1.14"},
+		{"gold-darwin-386-1.14.0", "go1.14"},
+
+		{"gold-linux-amd64-1.13.0", "go1.13"},
+		{"gold-linux-386-1.13.0", "go1.13"},
+		{"gold-windows-amd64-1.13.0", "go1.13"},
+		{"gold-windows-386-1.13.0", "go1.13"},
+		{"gold-darwin-amd64-1.13.0", "go1.13"},
+		{"gold-darwin-386-1.13.0", "go1.13"},
+
+		{"gold-linux-amd64-1.12.0", "go1.12"},
+		{"gold-linux-386-1.12.0", "go1.12"},
+		{"gold-windows-amd64-1.12.0", "go1.12"},
+		{"gold-windows-386-1.12.0", "go1.12"},
+		{"gold-darwin-amd64-1.12.0", "go1.12"},
+		{"gold-darwin-386-1.12.0", "go1.12"},
+
+		{"gold-linux-amd64-1.11.0", "go1.11"},
+		{"gold-linux-386-1.11.0", "go1.11"},
+		{"gold-windows-amd64-1.11.0", "go1.11"},
+		{"gold-windows-386-1.11.0", "go1.11"},
+		{"gold-darwin-amd64-1.11.0", "go1.11"},
+		{"gold-darwin-386-1.11.0", "go1.11"},
+
+		{"gold-linux-amd64-1.10.0", "go1.10"},
+		{"gold-linux-386-1.10.0", "go1.10"},
+		{"gold-windows-amd64-1.10.0", "go1.10"},
+		{"gold-windows-386-1.10.0", "go1.10"},
+		{"gold-darwin-amd64-1.10.0", "go1.10"},
+		{"gold-darwin-386-1.10.0", "go1.10"},
+
+		{"gold-linux-amd64-1.9.0", "go1.9"},
+		{"gold-linux-386-1.9.0", "go1.9"},
+		{"gold-windows-amd64-1.9.0", "go1.9"},
+		{"gold-windows-386-1.9.0", "go1.9"},
+		{"gold-darwin-amd64-1.9.0", "go1.9"},
+		{"gold-darwin-386-1.9.0", "go1.9"},
+
+		{"gold-linux-amd64-1.8.0", "go1.8"},
+		{"gold-linux-386-1.8.0", "go1.8"},
+		{"gold-windows-amd64-1.8.0", "go1.8"},
+		{"gold-windows-386-1.8.0", "go1.8"},
+		{"gold-darwin-amd64-1.8.0", "go1.8"},
+		{"gold-darwin-386-1.8.0", "go1.8"},
+	}
+
+	for _, test := range tests {
+		t.Run("parse version from "+test.f, func(t *testing.T) {
+			pt, err := filepath.Abs(filepath.Join("testdata", "gold", test.f))
+			r.NoError(err)
+
+			f, err := Open(pt)
+			r.NoError(err)
+			defer f.Close()
+
+			ver := tryFromSchedInit(f)
+			r.NotNil(ver)
+
+			r.Equal(goversions[test.version], ver)
 		})
 	}
 }

--- a/macho.go
+++ b/macho.go
@@ -65,20 +65,21 @@ func (m *machoFile) getSectionData(s string) (uint64, []byte, error) {
 }
 
 func (m *machoFile) getFileInfo() *FileInfo {
-	var wordSize int
+	fi := &FileInfo{
+		ByteOrder: m.file.ByteOrder,
+		OS:        "macOS",
+	}
 	switch m.file.Cpu {
 	case macho.Cpu386:
-		wordSize = intSize32
+		fi.WordSize = intSize32
+		fi.Arch = Arch386
 	case macho.CpuAmd64:
-		wordSize = intSize64
+		fi.WordSize = intSize64
+		fi.Arch = ArchAMD64
 	default:
 		panic("Unsupported architecture")
 	}
-	return &FileInfo{
-		ByteOrder: m.file.ByteOrder,
-		OS:        "macOS",
-		WordSize:  wordSize,
-	}
+	return fi
 }
 
 func (m *machoFile) getPCLNTABData() (uint64, []byte, error) {

--- a/pe.go
+++ b/pe.go
@@ -89,10 +89,12 @@ func (p *peFile) getFileInfo() *FileInfo {
 		fi.WordSize = intSize32
 		optHdr := p.file.OptionalHeader.(*pe.OptionalHeader32)
 		p.imageBase = uint64(optHdr.ImageBase)
+		fi.Arch = Arch386
 	} else {
 		fi.WordSize = intSize64
 		optHdr := p.file.OptionalHeader.(*pe.OptionalHeader64)
 		p.imageBase = optHdr.ImageBase
+		fi.Arch = ArchAMD64
 	}
 	return fi
 }


### PR DESCRIPTION
This commit adds new logic for detecting the Go compiler version used
when compiling the binary. It uses the schedinit function in the runtime
package to find the string identifier. This functionality works for
binaries compiled with 1.7 and newer.

PE, ELF and Mach-O binaries are supported. This will be used for x86
binaries only. The old logic is used as a fallback if this method fails
or not supported.