### PR TITLE
Fix no build ID causes error when opening a file

### DIFF
--- a/file.go
+++ b/file.go
@@ -75,10 +75,14 @@ func Open(filePath string) (*GoFile, error) {
 	}
 	gofile.FileInfo = gofile.fh.getFileInfo()
 
+	// If the ID has been removed or tampered with, this will fail. If we can't
+	// get a build ID, we skip it.
 	buildID, err := gofile.fh.getBuildID()
-	gofile.BuildID = buildID
+	if err == nil {
+		gofile.BuildID = buildID
+	}
 
-	return gofile, err
+	return gofile, nil
 }
 
 // GoFile is a structure representing a go binary file.


### PR DESCRIPTION
If the binary does not have a build ID, an error is returned. The lack
of build ID should not cause a failure when opening the file.