### PR TITLE
fix struct tag parse & support go1.17beta1

### DIFF
--- a/type.go
+++ b/type.go
@@ -246,6 +246,9 @@ func StructDef(typ *GoType) string {
 		} else {
 			buf += fmt.Sprintf("\n\t%s %s", f.FieldName, f)
 		}
+		if f.FieldTag != "" {
+			buf += "\t`" + f.FieldTag + "`"
+		}
 	}
 	if len(typ.Fields) > 0 {
 		buf += "\n"
@@ -803,6 +806,9 @@ func resolveName(sectionData []byte, offset uint64, flags uint8) (string, int) {
 }
 
 func resolveTag(offset, nameLen int, sectionData []byte) string {
+	if sectionData[offset]&(1<<1) == 0 {
+		return ""
+	}
 	o := offset + 3 + nameLen
 	tl := int(uint16(sectionData[o])<<8 | uint16(sectionData[o+1]))
 	if tl == 0 {

--- a/type.go
+++ b/type.go
@@ -790,21 +790,6 @@ func parseMethods(r *bytes.Reader, fileInfo *FileInfo, sectionData []byte, secti
 	return methods
 }
 
-// Helper function to resolve the type name.
-func resolveName(sectionData []byte, offset uint64, flags uint8) (string, int) {
-	// TODO(jk): Add bounds check.
-	nl := int(uint16(sectionData[offset+1])<<8 | uint16(sectionData[offset+2]))
-	if nl == 0 {
-		return "", 0
-	}
-	strData := string(sectionData[offset+uint64(3) : offset+uint64(3)+uint64(nl)])
-	if flags&tflagExtraStar != 0 {
-		// typ.Name = strData[1:]
-		return strData[1:], nl - 1
-	}
-	return strData, nl
-}
-
 func typeOffset(fileInfo *FileInfo, field _typeField) int64 {
 	intSize := intSize64
 	if fileInfo.WordSize == intSize32 {

--- a/type.go
+++ b/type.go
@@ -805,16 +805,6 @@ func resolveName(sectionData []byte, offset uint64, flags uint8) (string, int) {
 	return strData, nl
 }
 
-func resolveTag(offset, nameLen int, sectionData []byte) string {
-	o := offset + 3 + nameLen
-	noTag := sectionData[offset]&(1<<1) == 0
-	tl := int(uint16(sectionData[o])<<8 | uint16(sectionData[o+1]))
-	if noTag || tl == 0 {
-		return ""
-	}
-	return string(sectionData[o+2 : o+2+tl])
-}
-
 func typeOffset(fileInfo *FileInfo, field _typeField) int64 {
 	intSize := intSize64
 	if fileInfo.WordSize == intSize32 {

--- a/type.go
+++ b/type.go
@@ -806,12 +806,10 @@ func resolveName(sectionData []byte, offset uint64, flags uint8) (string, int) {
 }
 
 func resolveTag(offset, nameLen int, sectionData []byte) string {
-	if sectionData[offset]&(1<<1) == 0 {
-		return ""
-	}
 	o := offset + 3 + nameLen
+	noTag := sectionData[offset]&(1<<1) == 0
 	tl := int(uint16(sectionData[o])<<8 | uint16(sectionData[o+1]))
-	if tl == 0 {
+	if noTag || tl == 0 {
 		return ""
 	}
 	return string(sectionData[o+2 : o+2+tl])

--- a/type2.go
+++ b/type2.go
@@ -91,9 +91,6 @@ type typeParser struct {
 	// located.
 	typesData []byte
 
-	// version is the compiler version.
-	version string
-
 	// Parse functions
 
 	parseArrayType       arrayTypeParseFunc

--- a/type_test.go
+++ b/type_test.go
@@ -146,6 +146,13 @@ func TestGetTypes(t *testing.T) {
 
 					complexStructTested = true
 				}
+
+				if typ.Name == "cpu.option" && typ.PackagePath == "" &&
+					GoVersionCompare(f.FileInfo.goversion.Name, "go1.7beta1") >= 0 {
+					for _, field := range typ.Fields {
+						assert.Equal("", field.FieldTag, "Field Tag should be empty")
+					}
+				}
 			}
 			if GoVersionCompare(f.FileInfo.goversion.Name, "go1.7beta1") >= 0 {
 				assert.True(complexStructTested, "myComplexStruct was not found")
@@ -252,6 +259,12 @@ func TestStructDef(t *testing.T) {
 				{FieldName: "myFunc", Kind: reflect.Func, FuncArgs: []*GoType{{Kind: reflect.String}, {Kind: reflect.Int}}, FuncReturnVals: []*GoType{{Kind: reflect.Uint}}},
 				{FieldAnon: true, Kind: reflect.Struct, Name: "embeddedType"},
 			}}, complexStructWithAnonDef},
+		{&GoType{
+			Kind: reflect.Struct,
+			Name: "myStruct",
+			Fields: []*GoType{
+				{FieldName: "myString", Kind: reflect.String, FieldTag: `json:"String"`},
+			}}, structWithFieldTag},
 	}
 	for _, test := range tests {
 		assert.Equal(test.expected, StructDef(test.typ))
@@ -327,6 +340,10 @@ const complexStructWithAnonDef = `type myComplexStruct struct{
 	myFunc func(string, int) uint
 	embeddedType
 }`
+
+const structWithFieldTag = "type myStruct struct{\n" +
+	"	myString string	`json:\"String\"`\n" +
+	"}"
 
 const ifDef = `type geometry interface {
 	area() float64


### PR DESCRIPTION
fix struct field tag parse.
See: https://github.com/golang/go/blob/d19a53338fa6272b4fe9c39d66812a79e1464cd2/src/reflect/type.go#L488
