### PR TITLE
tweaks, basic DWARF-based info

### DIFF
--- a/dwarf.go
+++ b/dwarf.go
@@ -1,3 +1,20 @@
+// This file is part of GoRE.
+//
+// Copyright (C) 2019-2024 GoRE Authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 package gore
 
 import (

--- a/dwarf.go
+++ b/dwarf.go
@@ -20,11 +20,7 @@ func getGoRootFromDwarf(fh fileHandler) (string, bool) {
 }
 
 func getBuildVersionFromDwarf(fh fileHandler) (string, bool) {
-	s, ok := getDwarfString(fh, getDwarfStringCheck("runtime.buildVersion"))
-	if ok {
-		panic(s)
-	}
-	return s, ok
+	return getDwarfString(fh, getDwarfStringCheck("runtime.buildVersion"))
 }
 
 // DWARF entry plus any associated children
@@ -91,13 +87,11 @@ func commonStringCheck(fh fileHandler, entry *dwarf.Entry) (string, dwarfwalkSta
 	locationField := entry.AttrField(dwarf.AttrLocation)
 	if locationField == nil {
 		// unexpected failure
-		panic(entry)
 		return "", dwStop
 	}
 	location := locationField.Val.([]byte)
 	// DWARF address operation followed by the machine byte order encoded address
 	if location[0] != dwOpAddr {
-		panic(location[0])
 		return "", dwStop
 	}
 	var addr uint64
@@ -109,7 +103,6 @@ func commonStringCheck(fh fileHandler, entry *dwarf.Entry) (string, dwarfwalkSta
 
 	sectionBase, data, err := fh.getSectionDataFromAddress(addr)
 	if err != nil {
-		panic(err)
 		return "", dwStop
 	}
 	off := addr - sectionBase
@@ -119,7 +112,6 @@ func commonStringCheck(fh fileHandler, entry *dwarf.Entry) (string, dwarfwalkSta
 		var stringData32 [2]uint32
 		err = binary.Read(r, fh.getFileInfo().ByteOrder, &stringData32)
 		if err != nil {
-			panic(err)
 			return "", dwStop
 		}
 		stringData[0] = uint64(stringData32[0])
@@ -127,7 +119,6 @@ func commonStringCheck(fh fileHandler, entry *dwarf.Entry) (string, dwarfwalkSta
 	} else {
 		err = binary.Read(r, fh.getFileInfo().ByteOrder, &stringData)
 		if err != nil {
-			panic(err)
 			return "", dwStop
 		}
 	}
@@ -135,7 +126,6 @@ func commonStringCheck(fh fileHandler, entry *dwarf.Entry) (string, dwarfwalkSta
 	stringLen := stringData[1]
 	sectionBase, data, err = fh.getSectionDataFromAddress(addr)
 	if err != nil {
-		panic(err)
 		return "", dwStop
 	}
 	off = addr - sectionBase

--- a/dwarf.go
+++ b/dwarf.go
@@ -1,0 +1,171 @@
+package gore
+
+import (
+	"bytes"
+	"debug/dwarf"
+	"encoding/binary"
+)
+
+const (
+	// official DWARF language ID for Go
+	// https://dwarfstd.org/languages.html
+	dwLangGo int64 = 0x0016
+
+	// DWARF operation; used to encode type offsets
+	dwOpAddr = 0x03
+)
+
+func getGoRootFromDwarf(fh fileHandler) (string, bool) {
+	return getDwarfString(fh, getDwarfStringCheck("runtime.defaultGOROOT"))
+}
+
+func getBuildVersionFromDwarf(fh fileHandler) (string, bool) {
+	s, ok := getDwarfString(fh, getDwarfStringCheck("runtime.buildVersion"))
+	if ok {
+		panic(s)
+	}
+	return s, ok
+}
+
+// DWARF entry plus any associated children
+type dwarfEntryPlus struct {
+	entry    *dwarf.Entry
+	children []*dwarfEntryPlus
+}
+
+type dwarfwalkStatus uint8
+
+const (
+	dwStop dwarfwalkStatus = iota + 1
+	dwContinue
+	dwFound
+)
+
+func getDwarfString(fh fileHandler, check func(fh fileHandler, entry *dwarfEntryPlus) (string, dwarfwalkStatus)) (string, bool) {
+	data, err := fh.getDwarf()
+	if err != nil {
+		return "", false
+	}
+
+	r := data.Reader()
+	// walk through compilation units
+getValOuter:
+	for cu := dwarfReadEntry(r); cu != nil; cu = dwarfReadEntry(r) {
+		if langField := cu.entry.AttrField(dwarf.AttrLanguage); langField == nil || langField.Val != dwLangGo {
+			continue
+		}
+	getValInner:
+		for _, entry := range cu.children {
+			ret, status := check(fh, entry)
+			switch status {
+			case dwStop:
+				break getValOuter
+			case dwFound:
+				return ret, true
+			case dwContinue:
+				continue getValInner
+			}
+		}
+	}
+	return "", false
+}
+
+// get, by name, a DWARF entry corresponding to a string constant
+func getDwarfStringCheck(name string) func(fh fileHandler, entry *dwarfEntryPlus) (string, dwarfwalkStatus) {
+	return func(fh fileHandler, d *dwarfEntryPlus) (string, dwarfwalkStatus) {
+		entry := d.entry
+		nameField := entry.AttrField(dwarf.AttrName)
+		if nameField == nil {
+			return "", dwContinue
+		}
+
+		if fieldName := nameField.Val.(string); fieldName != name {
+			return "", dwContinue
+		}
+
+		return commonStringCheck(fh, entry)
+	}
+}
+
+func commonStringCheck(fh fileHandler, entry *dwarf.Entry) (string, dwarfwalkStatus) {
+	locationField := entry.AttrField(dwarf.AttrLocation)
+	if locationField == nil {
+		// unexpected failure
+		panic(entry)
+		return "", dwStop
+	}
+	location := locationField.Val.([]byte)
+	// DWARF address operation followed by the machine byte order encoded address
+	if location[0] != dwOpAddr {
+		panic(location[0])
+		return "", dwStop
+	}
+	var addr uint64
+	if fh.getFileInfo().WordSize == intSize32 {
+		addr = uint64(fh.getFileInfo().ByteOrder.Uint32(location[1:]))
+	} else {
+		addr = fh.getFileInfo().ByteOrder.Uint64(location[1:])
+	}
+
+	sectionBase, data, err := fh.getSectionDataFromAddress(addr)
+	if err != nil {
+		panic(err)
+		return "", dwStop
+	}
+	off := addr - sectionBase
+	r := bytes.NewReader(data[off:])
+	var stringData [2]uint64
+	if fh.getFileInfo().WordSize == intSize32 {
+		var stringData32 [2]uint32
+		err = binary.Read(r, fh.getFileInfo().ByteOrder, &stringData32)
+		if err != nil {
+			panic(err)
+			return "", dwStop
+		}
+		stringData[0] = uint64(stringData32[0])
+		stringData[1] = uint64(stringData32[1])
+	} else {
+		err = binary.Read(r, fh.getFileInfo().ByteOrder, &stringData)
+		if err != nil {
+			panic(err)
+			return "", dwStop
+		}
+	}
+	addr = stringData[0]
+	stringLen := stringData[1]
+	sectionBase, data, err = fh.getSectionDataFromAddress(addr)
+	if err != nil {
+		panic(err)
+		return "", dwStop
+	}
+	off = addr - sectionBase
+	raw := data[off : off+stringLen]
+	return string(raw), dwFound
+}
+
+func dwarfReadEntry(r *dwarf.Reader) *dwarfEntryPlus {
+	entry, _ := r.Next()
+	if entry == nil {
+		return nil
+	}
+	var children []*dwarfEntryPlus
+	if entry.Children {
+		children = dwarfReadChildren(r)
+	}
+	return &dwarfEntryPlus{
+		entry:    entry,
+		children: children,
+	}
+}
+
+func dwarfReadChildren(r *dwarf.Reader) []*dwarfEntryPlus {
+	var ret []*dwarfEntryPlus
+
+	for {
+		e := dwarfReadEntry(r)
+		if e.entry.Tag == 0 {
+			return ret
+		}
+		ret = append(ret, e)
+	}
+}

--- a/elf.go
+++ b/elf.go
@@ -113,14 +113,14 @@ func (e *elfFile) moduledataSection() string {
 	return ".noptrdata"
 }
 
-func (e *elfFile) getSectionDataFromOffset(off uint64) (uint64, []byte, error) {
+func (e *elfFile) getSectionDataFromAddress(address uint64) (uint64, []byte, error) {
 	for _, section := range e.file.Sections {
 		if section.Offset == 0 {
 			// Only exist in memory
 			continue
 		}
 
-		if section.Addr <= off && off < (section.Addr+section.Size) {
+		if section.Addr <= address && address < (section.Addr+section.Size) {
 			data, err := section.Data()
 			return section.Addr, data, err
 		}

--- a/elf.go
+++ b/elf.go
@@ -18,6 +18,7 @@
 package gore
 
 import (
+	"debug/dwarf"
 	"debug/elf"
 	"debug/gosym"
 	"errors"
@@ -177,4 +178,8 @@ func (e *elfFile) getBuildID() (string, error) {
 		return "", fmt.Errorf("error when getting note section: %w", err)
 	}
 	return parseBuildIDFromElf(data, e.file.ByteOrder)
+}
+
+func (e *elfFile) getDwarf() (*dwarf.Data, error) {
+	return e.file.DWARF()
 }

--- a/file.go
+++ b/file.go
@@ -19,6 +19,7 @@ package gore
 
 import (
 	"bytes"
+	"debug/dwarf"
 	"debug/gosym"
 	"encoding/binary"
 	"errors"
@@ -446,6 +447,7 @@ type fileHandler interface {
 	getBuildID() (string, error)
 	getFile() *os.File
 	getParsedFile() any
+	getDwarf() (*dwarf.Data, error)
 }
 
 func fileMagicMatch(buf, magic []byte) bool {

--- a/file.go
+++ b/file.go
@@ -47,7 +47,7 @@ func Open(filePath string) (*GoFile, error) {
 		return nil, err
 	}
 
-	_, err = f.Seek(0, 0)
+	_, err = f.Seek(0, io.SeekStart)
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +404,7 @@ func (f *GoFile) GetTypes() ([]*GoType, error) {
 
 // Bytes return a slice of raw bytes with the length in the file from the address.
 func (f *GoFile) Bytes(address uint64, length uint64) ([]byte, error) {
-	base, section, err := f.fh.getSectionDataFromOffset(address)
+	base, section, err := f.fh.getSectionDataFromAddress(address)
 	if err != nil {
 		return nil, err
 	}
@@ -438,7 +438,7 @@ type fileHandler interface {
 	getPCLNTab() (*gosym.Table, error)
 	getRData() ([]byte, error)
 	getCodeSection() (uint64, []byte, error)
-	getSectionDataFromOffset(uint64) (uint64, []byte, error)
+	getSectionDataFromAddress(uint64) (uint64, []byte, error)
 	getSectionData(string) (uint64, []byte, error)
 	getFileInfo() *FileInfo
 	getPCLNTABData() (uint64, []byte, error)

--- a/file_test.go
+++ b/file_test.go
@@ -171,7 +171,7 @@ func TestSetGoVersion(t *testing.T) {
 }
 
 type mockFileHandler struct {
-	mGetSectionDataFromOffset func(uint64) (uint64, []byte, error)
+	mGetSectionDataFromAddress func(uint64) (uint64, []byte, error)
 }
 
 func (m *mockFileHandler) getFile() *os.File {
@@ -198,8 +198,8 @@ func (m *mockFileHandler) getCodeSection() (uint64, []byte, error) {
 	panic("not implemented")
 }
 
-func (m *mockFileHandler) getSectionDataFromOffset(o uint64) (uint64, []byte, error) {
-	return m.mGetSectionDataFromOffset(o)
+func (m *mockFileHandler) getSectionDataFromAddress(a uint64) (uint64, []byte, error) {
+	return m.mGetSectionDataFromAddress(a)
 }
 
 func (m *mockFileHandler) getSectionData(string) (uint64, []byte, error) {
@@ -230,7 +230,7 @@ func TestBytes(t *testing.T) {
 	address := uint64(expectedBase + 2)
 	length := uint64(len(expectedBytes))
 	fh := &mockFileHandler{
-		mGetSectionDataFromOffset: func(a uint64) (uint64, []byte, error) {
+		mGetSectionDataFromAddress: func(a uint64) (uint64, []byte, error) {
 			if a > expectedBase+uint64(len(expectedSection)) || a < expectedBase {
 				return 0, nil, errors.New("out of bound")
 			}

--- a/file_test.go
+++ b/file_test.go
@@ -18,6 +18,7 @@
 package gore
 
 import (
+	"debug/dwarf"
 	"debug/elf"
 	"debug/gosym"
 	"debug/macho"
@@ -219,6 +220,10 @@ func (m *mockFileHandler) moduledataSection() string {
 }
 
 func (m *mockFileHandler) getBuildID() (string, error) {
+	panic("not implemented")
+}
+
+func (m *mockFileHandler) getDwarf() (*dwarf.Data, error) {
 	panic("not implemented")
 }
 

--- a/file_test.go
+++ b/file_test.go
@@ -289,3 +289,16 @@ func main() {
 	data += " | Test"
 }
 `
+
+const nostripSrc = `
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func main() {
+	fmt.Println(runtime.GOROOT())
+}
+`

--- a/goroot.go
+++ b/goroot.go
@@ -326,7 +326,11 @@ pkgLoop:
 }
 
 func findGoRootPath(f *GoFile) (string, error) {
-	var goroot string
+	// if DWARF debug info exists, then this can simply be obtained from there
+	if goroot, ok := getGoRootFromDwarf(f.fh); ok {
+		return goroot, nil
+	}
+
 	// There is no GOROOT function may be inlined (after go1.16)
 	// at this time GOROOT is obtained through time_init function
 	goroot, err := tryFromGOROOT(f)

--- a/goversion.go
+++ b/goversion.go
@@ -22,10 +22,11 @@ package gore
 import (
 	"bytes"
 	"errors"
+	"regexp"
+
 	"github.com/goretk/gore/extern"
 	"github.com/goretk/gore/extern/gover"
 	"golang.org/x/arch/x86/x86asm"
-	"regexp"
 )
 
 var goVersionMatcher = regexp.MustCompile(`(go[\d+.]*(beta|rc)?[\d*])`)
@@ -119,7 +120,7 @@ func tryFromSchedInit(f *GoFile) *GoVersion {
 		is32 = true
 	}
 
-	// Find shedinit function.
+	// Find schedinit function.
 	var fcn *Function
 	std, err := f.GetSTDLib()
 	if err != nil {
@@ -140,7 +141,7 @@ pkgLoop:
 		}
 	}
 
-	// Check if the functions was found
+	// Check if the function was found
 	if fcn == nil {
 		// If we can't find the function there is nothing to do.
 		return nil

--- a/goversion.go
+++ b/goversion.go
@@ -66,6 +66,13 @@ func GoVersionCompare(a, b string) int {
 }
 
 func findGoCompilerVersion(f *GoFile) (*GoVersion, error) {
+	// if DWARF debug info exists, then this can simply be obtained from there
+	if gover, ok := getBuildVersionFromDwarf(f.fh); ok {
+		if ver := ResolveGoVersion(gover); ver != nil {
+			return ver, nil
+		}
+	}
+
 	// Try to determine the version based on the schedinit function.
 	if v := tryFromSchedInit(f); v != nil {
 		return v, nil

--- a/macho.go
+++ b/macho.go
@@ -18,6 +18,7 @@
 package gore
 
 import (
+	"debug/dwarf"
 	"debug/gosym"
 	"debug/macho"
 	"fmt"
@@ -141,4 +142,8 @@ func (m *machoFile) getBuildID() (string, error) {
 		return "", fmt.Errorf("failed to get code section: %w", err)
 	}
 	return parseBuildIDFromRaw(data)
+}
+
+func (m *machoFile) getDwarf() (*dwarf.Data, error) {
+	return m.file.DWARF()
 }

--- a/macho.go
+++ b/macho.go
@@ -82,14 +82,14 @@ func (m *machoFile) getCodeSection() (uint64, []byte, error) {
 	return m.getSectionData("__text")
 }
 
-func (m *machoFile) getSectionDataFromOffset(off uint64) (uint64, []byte, error) {
+func (m *machoFile) getSectionDataFromAddress(address uint64) (uint64, []byte, error) {
 	for _, section := range m.file.Sections {
 		if section.Offset == 0 {
 			// Only exist in memory
 			continue
 		}
 
-		if section.Addr <= off && off < (section.Addr+section.Size) {
+		if section.Addr <= address && address < (section.Addr+section.Size) {
 			data, err := section.Data()
 			return section.Addr, data, err
 		}

--- a/moduledata.go
+++ b/moduledata.go
@@ -24,10 +24,11 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/goretk/gore/extern"
-	"github.com/goretk/gore/extern/gover"
 	"io"
 	"strconv"
+
+	"github.com/goretk/gore/extern"
+	"github.com/goretk/gore/extern/gover"
 )
 
 // Moduledata holds information about the layout of the executable image in memory.
@@ -168,7 +169,8 @@ func (m moduledata) TypeLink() ModuleDataSection {
 
 // TypeLinkData returns the typelink section.
 func (m moduledata) TypeLinkData() ([]int32, error) {
-	base, data, err := m.fh.getSectionDataFromOffset(m.TypelinkAddr)
+	base, data, err := m.fh.getSectionDataFromAddress(m.TypelinkAddr)
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the typelink data section: %w", err)
 	}
@@ -209,7 +211,7 @@ func (m ModuleDataSection) Data() ([]byte, error) {
 	if m.Length == 0 {
 		return []byte{}, nil
 	}
-	base, data, err := m.fh.getSectionDataFromOffset(m.Address)
+	base, data, err := m.fh.getSectionDataFromAddress(m.Address)
 	if err != nil {
 		return nil, fmt.Errorf("getting module data section failed: %w", err)
 	}

--- a/pe.go
+++ b/pe.go
@@ -18,6 +18,7 @@
 package gore
 
 import (
+	"debug/dwarf"
 	"debug/gosym"
 	"debug/pe"
 	"encoding/binary"
@@ -157,4 +158,8 @@ func (p *peFile) getBuildID() (string, error) {
 		return "", fmt.Errorf("failed to get code section: %w", err)
 	}
 	return parseBuildIDFromRaw(data)
+}
+
+func (p *peFile) getDwarf() (*dwarf.Data, error) {
+	return p.file.DWARF()
 }

--- a/pe.go
+++ b/pe.go
@@ -111,14 +111,14 @@ func (p *peFile) getPCLNTABData() (uint64, []byte, error) {
 	return p.imageBase + uint64(b), d, e
 }
 
-func (p *peFile) getSectionDataFromOffset(off uint64) (uint64, []byte, error) {
+func (p *peFile) getSectionDataFromAddress(address uint64) (uint64, []byte, error) {
 	for _, section := range p.file.Sections {
 		if section.Offset == 0 {
 			// Only exist in memory
 			continue
 		}
 
-		if p.imageBase+uint64(section.VirtualAddress) <= off && off < p.imageBase+uint64(section.VirtualAddress+section.Size) {
+		if p.imageBase+uint64(section.VirtualAddress) <= address && address < p.imageBase+uint64(section.VirtualAddress+section.Size) {
 			data, err := section.Data()
 			return p.imageBase + uint64(section.VirtualAddress), data, err
 		}

--- a/type.go
+++ b/type.go
@@ -784,34 +784,34 @@ func parseMethods(r *bytes.Reader, fileInfo *FileInfo, sectionData []byte, secti
 }
 
 func typeOffset(fileInfo *FileInfo, field _typeField) int64 {
-	intSize := intSize64
+	intSize := int64(intSize64)
 	if fileInfo.WordSize == intSize32 {
 		intSize = intSize32
 	}
-	if field == _typeFieldSize {
-		return int64(0)
-	}
 
-	if field == _typeFieldKind {
-		return int64(2*intSize + 4 + 3)
-	}
+	switch field {
+	case _typeFieldSize:
+		return 0
 
-	if field == _typeFieldStr {
-		return int64(4*intSize + 4 + 4)
-	}
+	case _typeFieldKind:
+		return 2*intSize + 4 + 3
 
-	if field == _typeFieldFlag {
-		return int64(2*intSize + 4)
-	}
+	case _typeFieldStr:
+		return 4*intSize + 4 + 4
 
-	if field == _typeFieldEnd {
+	case _typeFieldFlag:
+		return 2*intSize + 4
+
+	case _typeFieldEnd:
 		if GoVersionCompare(fileInfo.goversion.Name, "go1.6beta1") < 0 {
-			return int64(8*intSize + 8)
+			return 8*intSize + 8
 		}
 		if GoVersionCompare(fileInfo.goversion.Name, "go1.7beta1") < 0 {
-			return int64(7*intSize + 8)
+			return 7*intSize + 8
 		}
-		return int64(4*intSize + 16)
+		return 4*intSize + 16
+
+	default:
+		return -1
 	}
-	return int64(-1)
 }

--- a/type.go
+++ b/type.go
@@ -82,7 +82,7 @@ func getTypes(fileInfo *FileInfo, f fileHandler, md moduledata) (map[uint64]*GoT
 }
 
 func getLegacyTypes(fileInfo *FileInfo, f fileHandler, md moduledata) (map[uint64]*GoType, error) {
-	typelinkAddr, typelinkData, err := f.getSectionDataFromOffset(md.TypelinkAddr)
+	typelinkAddr, typelinkData, err := f.getSectionDataFromAddress(md.TypelinkAddr)
 	if err != nil {
 		return nil, fmt.Errorf("no typelink section found: %w", err)
 	}
@@ -95,15 +95,15 @@ func getLegacyTypes(fileInfo *FileInfo, f fileHandler, md moduledata) (map[uint6
 	goTypes := make(map[uint64]*GoType)
 	for i := uint64(0); i < md.TypelinkLen; i++ {
 		// Type offsets are always *_type
-		off, err := readUIntTo64(r, fileInfo.ByteOrder, fileInfo.WordSize == intSize32)
+		address, err := readUIntTo64(r, fileInfo.ByteOrder, fileInfo.WordSize == intSize32)
 		if err != nil {
 			return nil, err
 		}
-		baseAddr, baseData, err := f.getSectionDataFromOffset(off)
+		baseAddr, baseData, err := f.getSectionDataFromAddress(address)
 		if err != nil {
 			continue
 		}
-		typ := typeParse(goTypes, fileInfo, off-baseAddr, baseData, baseAddr)
+		typ := typeParse(goTypes, fileInfo, address-baseAddr, baseData, baseAddr)
 		if typ == nil {
 			continue
 		}


### PR DESCRIPTION
This PR sets up the groundwork for getting DWARF-based info from ELF files, and adds fetching the built-in goroot and build version using it as examples, which currently otherwise require hacks like disassembly of code. The addresses and values of various other values (e.g `runtime.firstmoduledata` for the moduledata, or various type definitions) could be located as well.
This, of course, has the drawback of only working on ELF and requiring DWARF to not be stripped, though it should be portable across all Go platforms which use ELF, both by OS and CPU architecture. And DWARF is, by default, included.

This PR also includes some housekeeping and tweaks:
* bumping dependencies
* simplifying `typeOffset()`
* renaming `getSectionDataFromOffset` to `getSectionDataFromAddress` for clarity (the "offset" passed as an argument is a memory address, not a file offset)
* replace uses of the deprecated `io/ioutil` module with equivalent code
* replace some `f.Seek(x, 0)` calls with `f.Seek(x, io.SeekStart)` to remove the magic value
* run `go generate` to update `gopkg_gen.go` and `stdpkg_gen.go`
* fix some typoes
* do not silently ignore some error values
* update tests to handle go.12.0 correctly and add said version to `testdata/build.go` (todo: PR to [/goretk/testdata](/goretk/testdata))