### PR TITLE
feat: expose content of fileHandler

### DIFF
--- a/file.go
+++ b/file.go
@@ -138,6 +138,22 @@ func (f *GoFile) init() error {
 	return returnVal
 }
 
+// GetFile returns the raw file opened by the library.
+func (f *GoFile) GetFile() *os.File {
+	return f.fh.GetFile()
+}
+
+// GetParsedFile returns the parsed file, should be cast based on the file type.
+// Possible types are:
+//   - *elf.File
+//   - *pe.File
+//   - *macho.File
+//
+// all from the debug package.
+func (f *GoFile) GetParsedFile() any {
+	return f.fh.GetParsedFile()
+}
+
 // GetCompilerVersion returns the Go compiler version of the compiler
 // that was used to compile the binary.
 func (f *GoFile) GetCompilerVersion() (*GoVersion, error) {
@@ -368,7 +384,8 @@ type fileHandler interface {
 	getPCLNTABData() (uint64, []byte, error)
 	moduledataSection() string
 	getBuildID() (string, error)
-	getFile() *os.File
+	GetFile() *os.File
+	GetParsedFile() any
 }
 
 func fileMagicMatch(buf, magic []byte) bool {

--- a/file_test.go
+++ b/file_test.go
@@ -20,7 +20,6 @@ package gore
 import (
 	"debug/gosym"
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -43,13 +42,13 @@ func TestIssue11NoNoteSectionELF(t *testing.T) {
 	if err != nil {
 		panic("No go tool chain found: " + err.Error())
 	}
-	tmpdir, err := ioutil.TempDir("", "TestGORE-Issue11")
+	tmpdir, err := os.MkdirTemp("", "TestGORE-Issue11")
 	if err != nil {
 		panic(err)
 	}
 	defer os.RemoveAll(tmpdir)
 	src := filepath.Join(tmpdir, "a.go")
-	err = ioutil.WriteFile(src, []byte(testresourcesrc), 0644)
+	err = os.WriteFile(src, []byte(testresourcesrc), 0644)
 	if err != nil {
 		panic(err)
 	}
@@ -163,7 +162,11 @@ type mockFileHandler struct {
 	mGetSectionDataFromOffset func(uint64) (uint64, []byte, error)
 }
 
-func (m *mockFileHandler) getFile() *os.File {
+func (m *mockFileHandler) GetFile() *os.File {
+	panic("not implemented")
+}
+
+func (m *mockFileHandler) GetParsedFile() any {
 	panic("not implemented")
 }
 
@@ -242,7 +245,7 @@ func getGoldenResources() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	folder, err := ioutil.ReadDir(filepath.Join(folderPath, "gold"))
+	folder, err := os.ReadDir(filepath.Join(folderPath, "gold"))
 	if err != nil {
 		return nil, err
 	}

--- a/file_test.go
+++ b/file_test.go
@@ -58,11 +58,11 @@ func TestIssue11NoNoteSectionELF(t *testing.T) {
 	exe := filepath.Join(tmpdir, "a")
 	args := []string{"build", "-o", exe, "-ldflags", "-s -w -buildid=", src}
 	cmd := exec.Command(goBin, args...)
-	gopatch := os.Getenv("GOPATH")
-	if gopatch == "" {
-		gopatch = tmpdir
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		gopath = tmpdir
 	}
-	cmd.Env = append(cmd.Env, "GOCACHE="+tmpdir, "GOOS=linux", "GOPATH="+gopatch, "GOTMPDIR="+tmpdir)
+	cmd.Env = append(cmd.Env, "GOCACHE="+tmpdir, "GOOS=linux", "GOPATH="+gopath, "GOTMPDIR="+tmpdir)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		panic("building test executable failed: " + string(out))

--- a/macho.go
+++ b/macho.go
@@ -37,12 +37,18 @@ func openMachO(fp string) (*machoFile, error) {
 	return &machoFile{file: f, osFile: osFile}, nil
 }
 
+var _ fileHandler = (*machoFile)(nil)
+
 type machoFile struct {
 	file   *macho.File
 	osFile *os.File
 }
 
-func (m *machoFile) getFile() *os.File {
+func (m *machoFile) GetParsedFile() any {
+	return m.file
+}
+
+func (m *machoFile) GetFile() *os.File {
 	return m.osFile
 }
 

--- a/modinfo.go
+++ b/modinfo.go
@@ -39,7 +39,7 @@ type BuildInfo struct {
 }
 
 func (f *GoFile) extractBuildInfo() (*BuildInfo, error) {
-	info, err := buildinfo.Read(f.fh.getFile())
+	info, err := buildinfo.Read(f.fh.GetFile())
 	if err != nil {
 		return nil, fmt.Errorf("error when extracting build information: %w", err)
 	}

--- a/pe.go
+++ b/pe.go
@@ -50,6 +50,8 @@ func openPE(fp string) (peF *peFile, err error) {
 	return
 }
 
+var _ fileHandler = (*peFile)(nil)
+
 type peFile struct {
 	file        *pe.File
 	osFile      *os.File
@@ -57,7 +59,11 @@ type peFile struct {
 	imageBase   uint64
 }
 
-func (p *peFile) getFile() *os.File {
+func (p *peFile) GetParsedFile() any {
+	return p.file
+}
+
+func (p *peFile) GetFile() *os.File {
 	return p.osFile
 }
 


### PR DESCRIPTION
This patch makes it possible for users to access the `fileHandler` internals. So they don't have to pay the overhead of parsing the file again