### PR TITLE
feat: add symbol load support and accurate some operation

### DIFF
--- a/elf.go
+++ b/elf.go
@@ -106,7 +106,7 @@ func (e *elfFile) getPCLNTABData() (uint64, []byte, error) {
 		return 0, nil, fmt.Errorf("failed to get section: .data.rel.ro: %w", err)
 	}
 
-	buf, err := searchSectionForTab(data)
+	buf, err := searchSectionForTab(data, e.file.FileHeader.ByteOrder)
 	if err != nil {
 		return 0, nil, fmt.Errorf("error when search for pclntab: %w", err)
 	}

--- a/elf.go
+++ b/elf.go
@@ -57,7 +57,7 @@ func (e *elfFile) initSymTab() error {
 			return
 		}
 		for _, sym := range syms {
-			e.symtab.table[sym.Name] = symbol{
+			e.symtab.table[sym.Name] = Symbol{
 				Name:  sym.Name,
 				Value: sym.Value,
 				Size:  sym.Size,

--- a/elf.go
+++ b/elf.go
@@ -203,7 +203,7 @@ func (e *elfFile) getPCLNTABData() (uint64, []byte, error) {
 	// If we have symbol data, we can use that to find the pclntab.
 	if ok, err := e.hasSymbolTable(); err != nil && ok {
 		start, _, data := e.symbolData("runtime.pclntab", "runtime.epclntab")
-		if data != nil {
+		if data != nil && start != 0 {
 			return start, data, nil
 		}
 	}

--- a/elf.go
+++ b/elf.go
@@ -56,7 +56,7 @@ func (e *elfFile) initSymTab() (map[string]Symbol, error) {
 		if !errors.Is(err, elf.ErrNoSymbols) {
 			return nil, fmt.Errorf("error when getting the symbols: %w", err)
 		}
-		return nil, nil
+		return nil, ErrSymbolNotFound
 	}
 	symm := make(map[string]Symbol)
 	for _, sym := range syms {

--- a/elf.go
+++ b/elf.go
@@ -69,14 +69,6 @@ func (e *elfFile) initSymTab() (map[string]Symbol, error) {
 	return symm, nil
 }
 
-func (e *elfFile) hasSymbolTable() (bool, error) {
-	symm, err := e.getsymtab()
-	if err != nil {
-		return false, err
-	}
-	return len(symm) > 0, nil
-}
-
 func (e *elfFile) getSymbol(name string) (uint64, uint64, error) {
 	symm, err := e.getsymtab()
 	if err != nil {

--- a/elf.go
+++ b/elf.go
@@ -69,16 +69,16 @@ func (e *elfFile) initSymTab() (map[string]Symbol, error) {
 	return symm, nil
 }
 
-func (e *elfFile) getSymbol(name string) (uint64, uint64, error) {
+func (e *elfFile) getSymbol(name string) (Symbol, error) {
 	symm, err := e.getsymtab()
 	if err != nil {
-		return 0, 0, err
+		return Symbol{}, err
 	}
 	sym, ok := symm[name]
 	if !ok {
-		return 0, 0, ErrSymbolNotFound
+		return Symbol{}, ErrSymbolNotFound
 	}
-	return sym.Value, sym.Size, nil
+	return sym, nil
 }
 
 func (e *elfFile) getParsedFile() any {

--- a/file.go
+++ b/file.go
@@ -401,6 +401,16 @@ func (f *GoFile) PCLNTab() (*gosym.Table, error) {
 		// be located within the binary's text section, it may not be at the start of the section. For example,
 		// external linkers may add additional code to the section before the "Go" code. We can find "runtime.text"
 		// in the moduledata structure in the binary.
+		// If we have the symbol table, just get it
+		if ok, err := f.fh.hasSymbolTable(); ok && err == nil {
+			f.runtimeText, _, err = f.fh.getSymbol("runtime.text")
+			if err != nil {
+				f.pclntabError = fmt.Errorf("failed to get the symbol runtime.text: %w", err)
+				return
+			}
+		}
+
+		// Otherwise, we need to search it
 		_, moddataSection, err := f.fh.getSectionData(f.fh.moduledataSection())
 		if err != nil {
 			f.pclntabError = fmt.Errorf("failed to get the section %s where the moduledata structure is stored: %w", f.fh.moduledataSection(), err)

--- a/file.go
+++ b/file.go
@@ -403,9 +403,9 @@ func (f *GoFile) PCLNTab() (*gosym.Table, error) {
 		// in the moduledata structure in the binary.
 		// If we have the symbol table, just get it
 		if ok, err := f.fh.hasSymbolTable(); ok && err == nil {
-			f.runtimeText, _, err = f.fh.getSymbol("runtime.text")
-			if err != nil {
-				f.pclntabError = fmt.Errorf("failed to get the symbol runtime.text: %w", err)
+			val, _, err := f.fh.getSymbol("runtime.text")
+			if err == nil {
+				f.runtimeText = val
 				return
 			}
 		}

--- a/file.go
+++ b/file.go
@@ -524,11 +524,7 @@ func (f *GoFile) findRuntimeText(textStart, textEnd, pclntabAddr uint64, modSect
 
 // GetTypes returns a map of all types found in the binary file.
 func (f *GoFile) GetTypes() ([]*GoType, error) {
-	err := f.ensureCompilerVersion()
-	if err != nil {
-		return nil, err
-	}
-	err = f.initModuleData()
+	err := f.initModuleData()
 	if err != nil {
 		return nil, err
 	}

--- a/file.go
+++ b/file.go
@@ -573,6 +573,9 @@ func sortTypes(types map[uint64]*GoType) []*GoType {
 
 type fileHandler interface {
 	io.Closer
+	// returns the size, value and error
+	getSymbol(name string) (uint64, uint64, error)
+	hasSymbolTable() (bool, error)
 	getRData() ([]byte, error)
 	getCodeSection() (uint64, []byte, error)
 	getSectionDataFromAddress(uint64) (uint64, []byte, error)

--- a/file.go
+++ b/file.go
@@ -154,7 +154,7 @@ func (f *GoFile) initModuleData() error {
 			f.initModuleDataError = err
 			return
 		}
-		f.moduledata, f.initModuleDataError = extractModuledata(f.FileInfo, f.fh)
+		f.moduledata, f.initModuleDataError = extractModuledata(f)
 	})
 	return f.initModuleDataError
 }
@@ -385,8 +385,7 @@ func (f *GoFile) Close() error {
 	return f.fh.Close()
 }
 
-// PCLNTab returns the PCLN table.
-func (f *GoFile) PCLNTab() (*gosym.Table, error) {
+func (f *GoFile) initPclntab() error {
 	f.pclntabOnce.Do(func() {
 		addr, data, err := f.fh.getPCLNTABData()
 		if err != nil {
@@ -444,10 +443,15 @@ func (f *GoFile) PCLNTab() (*gosym.Table, error) {
 		}
 		f.runtimeText = runtimeText
 	})
-	if f.pclntabError != nil {
-		return nil, f.pclntabError
-	}
+	return f.pclntabError
+}
 
+// PCLNTab returns the PCLN table.
+func (f *GoFile) PCLNTab() (*gosym.Table, error) {
+	err := f.initPclntab()
+	if err != nil {
+		return nil, err
+	}
 	return gosym.NewTable(make([]byte, 0), gosym.NewLineTable(f.pclntabBytes, f.runtimeText))
 }
 

--- a/file.go
+++ b/file.go
@@ -404,15 +404,11 @@ func (f *GoFile) getPCLNTABDataBySymbol() (uint64, []byte, error) {
 	if end < start {
 		return 0, nil, errors.New("invalid pclntab symbols")
 	}
-	sectStart, data, err := f.fh.getSectionDataFromAddress(start)
+	data, err := f.Bytes(start, end-start)
 	if err != nil {
 		return 0, nil, err
 	}
-	// ensure that the pclntab is within the same section
-	if end-sectStart > uint64(len(data)) {
-		return 0, nil, errors.New("pclntab out of bounds")
-	}
-	return start, data[start-sectStart : end-sectStart], nil
+	return start, data, nil
 }
 
 func (f *GoFile) initPclntab() error {

--- a/file.go
+++ b/file.go
@@ -573,7 +573,7 @@ func sortTypes(types map[uint64]*GoType) []*GoType {
 
 type fileHandler interface {
 	io.Closer
-	// returns the size, value and error
+	// returns the value, size and error
 	getSymbol(name string) (uint64, uint64, error)
 	hasSymbolTable() (bool, error)
 	getRData() ([]byte, error)

--- a/file.go
+++ b/file.go
@@ -417,7 +417,7 @@ func (f *GoFile) PCLNTab() (*gosym.Table, error) {
 		}
 
 		// Since the moduledata starts with the address to the pclntab, we can use this to find the moduledata structure.
-		runtimeText, err := f.findRuntimeText(textStart, textStart+uint64(len(textData)), f.pclntabAddr, moddataSection)
+		runtimeText, err := f.findRuntimeText(textStart, textStart+uint64(len(textData)), addr, moddataSection)
 		if err != nil {
 			if f.FileInfo.OS == "macOS" && f.FileInfo.Arch == ArchARM64 {
 				t, err := f.findRuntimeTextMachoChainedFixups(f.pclntabAddr)

--- a/file_test.go
+++ b/file_test.go
@@ -225,6 +225,14 @@ func (m *mockFileHandler) getFile() *os.File {
 	panic("not implemented")
 }
 
+func (m *mockFileHandler) hasSymbolTable() (bool, error) {
+	panic("not implemented")
+}
+
+func (m *mockFileHandler) getSymbol(name string) (uint64, uint64, error) {
+	panic("not implemented")
+}
+
 func (m *mockFileHandler) getParsedFile() any {
 	panic("not implemented")
 }
@@ -321,6 +329,11 @@ func getGoldenResources() ([]string, error) {
 const testresourcesrc = `
 package main
 
+import (
+	"fmt"
+	"runtime"
+)
+
 //go:noinline
 func getData() string {
 	return "Name: GoRE"
@@ -329,18 +342,6 @@ func getData() string {
 func main() {
 	data := getData()
 	data += " | Test"
-}
-`
-
-const nostripSrc = `
-package main
-
-import (
-	"fmt"
-	"runtime"
-)
-
-func main() {
 	fmt.Println(runtime.GOROOT())
 }
 `

--- a/file_test.go
+++ b/file_test.go
@@ -73,8 +73,6 @@ func TestIssue11NoNoteSectionELF(t *testing.T) {
 }
 
 func TestIssue79PIEAndExternalLinker(t *testing.T) {
-	r := require.New(t)
-
 	tests := []struct {
 		file     string
 		version  string
@@ -87,6 +85,8 @@ func TestIssue79PIEAndExternalLinker(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.file, func(t *testing.T) {
+			r := require.New(t)
+
 			testFile := filepath.Join("testdata", "gold", test.file)
 
 			f, err := Open(testFile)

--- a/file_test.go
+++ b/file_test.go
@@ -343,5 +343,6 @@ func main() {
 	data := getData()
 	data += " | Test"
 	fmt.Println(runtime.GOROOT())
+	fmt.Println(data)
 }
 `

--- a/file_test.go
+++ b/file_test.go
@@ -225,7 +225,7 @@ func (m *mockFileHandler) getFile() *os.File {
 	panic("not implemented")
 }
 
-func (m *mockFileHandler) getSymbol(name string) (uint64, uint64, error) {
+func (m *mockFileHandler) getSymbol(name string) (Symbol, error) {
 	panic("not implemented")
 }
 

--- a/file_test.go
+++ b/file_test.go
@@ -225,10 +225,6 @@ func (m *mockFileHandler) getFile() *os.File {
 	panic("not implemented")
 }
 
-func (m *mockFileHandler) hasSymbolTable() (bool, error) {
-	panic("not implemented")
-}
-
 func (m *mockFileHandler) getSymbol(name string) (uint64, uint64, error) {
 	panic("not implemented")
 }

--- a/goversion.go
+++ b/goversion.go
@@ -24,9 +24,10 @@ import (
 	"errors"
 	"regexp"
 
+	"golang.org/x/arch/x86/x86asm"
+
 	"github.com/goretk/gore/extern"
 	"github.com/goretk/gore/extern/gover"
-	"golang.org/x/arch/x86/x86asm"
 )
 
 var goVersionMatcher = regexp.MustCompile(`(go[\d+.]*(beta|rc)?[\d*])`)
@@ -132,11 +133,9 @@ func tryFromSchedInit(f *GoFile) *GoVersion {
 		is32 = true
 	}
 
-	if ok, err := f.fh.hasSymbolTable(); ok && err == nil {
-		addr, size, err = f.fh.getSymbol("runtime.schedinit")
-		if err == nil {
-			goto disasm
-		}
+	addr, size, err = f.fh.getSymbol("runtime.schedinit")
+	if err == nil {
+		goto disasm
 	}
 
 	// Find schedinit function.

--- a/goversion.go
+++ b/goversion.go
@@ -133,8 +133,9 @@ func tryFromSchedInit(f *GoFile) *GoVersion {
 		is32 = true
 	}
 
-	addr, size, err = f.fh.getSymbol("runtime.schedinit")
+	sym, err := f.fh.getSymbol("runtime.schedinit")
 	if err == nil {
+		addr = sym.Value
 		goto disasm
 	}
 

--- a/goversion.go
+++ b/goversion.go
@@ -136,6 +136,7 @@ func tryFromSchedInit(f *GoFile) *GoVersion {
 	sym, err := f.fh.getSymbol("runtime.schedinit")
 	if err == nil {
 		addr = sym.Value
+		size = sym.Size
 		goto disasm
 	}
 

--- a/goversion.go
+++ b/goversion.go
@@ -168,7 +168,6 @@ pkgLoop:
 	size = fcn.End - fcn.Offset
 
 disasm:
-
 	// Get the raw hex.
 	buf, err := f.Bytes(addr, size)
 	if err != nil {
@@ -202,10 +201,10 @@ disasm:
 		// Check what it's loading and if it's pointing to the compiler version used.
 		// First assume that the address is a direct addressing.
 		arg := inst.Args[1].(x86asm.Mem)
-		addr := arg.Disp
+		disp := arg.Disp
 		if arg.Base == x86asm.EIP || arg.Base == x86asm.RIP {
 			// If the addressing is based on the instruction pointer, fix the address.
-			addr = addr + int64(fcn.Offset) + int64(s)
+			disp += int64(addr) + int64(s)
 		}
 
 		// If the addressing is based on the stack pointer, this is not the right
@@ -216,7 +215,7 @@ disasm:
 
 		// Resolve the pointer to the string. If we get no data, this is not the
 		// right instruction.
-		b, _ := f.Bytes(uint64(addr), uint64(0x20))
+		b, _ := f.Bytes(uint64(disp), uint64(0x20))
 		if b == nil {
 			continue
 		}

--- a/macho.go
+++ b/macho.go
@@ -83,7 +83,7 @@ func (m *machoFile) initSymtab() error {
 			m.symtab.table[sym.Name] = sym
 		}
 	})
-	return m.symtab.err
+	return nil
 }
 
 func (m *machoFile) hasSymbolTable() (bool, error) {

--- a/macho.go
+++ b/macho.go
@@ -84,12 +84,12 @@ func (m *machoFile) initSymtab() map[string]Symbol {
 	return symm
 }
 
-func (m *machoFile) getSymbol(name string) (uint64, uint64, error) {
+func (m *machoFile) getSymbol(name string) (Symbol, error) {
 	sym, ok := m.getsymtab()[name]
 	if !ok {
-		return 0, 0, ErrSymbolNotFound
+		return Symbol{}, ErrSymbolNotFound
 	}
-	return sym.Value, sym.Size, nil
+	return sym, nil
 }
 
 func (m *machoFile) getParsedFile() any {

--- a/macho.go
+++ b/macho.go
@@ -65,13 +65,13 @@ func (m *machoFile) initSymtab() error {
 		}
 		slices.Sort(addrs)
 
-		var syms []symbol
+		var syms []Symbol
 		for _, s := range m.file.Symtab.Syms {
 			if s.Type&stabTypeMask != 0 {
 				// Skip stab debug info.
 				continue
 			}
-			sym := symbol{Name: s.Name, Value: s.Value}
+			sym := Symbol{Name: s.Name, Value: s.Value}
 			i := sort.Search(len(addrs), func(x int) bool { return addrs[x] > s.Value })
 			if i < len(addrs) {
 				sym.Size = addrs[i] - s.Value

--- a/macho.go
+++ b/macho.go
@@ -22,6 +22,8 @@ import (
 	"debug/macho"
 	"fmt"
 	"os"
+	"slices"
+	"sort"
 )
 
 func openMachO(fp string) (*machoFile, error) {
@@ -34,7 +36,7 @@ func openMachO(fp string) (*machoFile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error when parsing the Mach-O file: %w", err)
 	}
-	return &machoFile{file: f, osFile: osFile}, nil
+	return &machoFile{file: f, osFile: osFile, symtab: newSymbolTableOnce()}, nil
 }
 
 var _ fileHandler = (*machoFile)(nil)
@@ -42,6 +44,62 @@ var _ fileHandler = (*machoFile)(nil)
 type machoFile struct {
 	file   *macho.File
 	osFile *os.File
+	symtab *symbolTableOnce
+}
+
+func (m *machoFile) initSymtab() error {
+	m.symtab.Do(func() {
+		if m.file.Symtab == nil {
+			// just do nothing, keep err nil and table empty
+			return
+		}
+		const stabTypeMask = 0xe0
+		// Build a sorted list of addresses of all symbols.
+		// We infer the size of a symbol by looking at where the next symbol begins.
+		var addrs []uint64
+		for _, s := range m.file.Symtab.Syms {
+			// Skip stab debug info.
+			if s.Type&stabTypeMask == 0 {
+				addrs = append(addrs, s.Value)
+			}
+		}
+		slices.Sort(addrs)
+
+		var syms []symbol
+		for _, s := range m.file.Symtab.Syms {
+			if s.Type&stabTypeMask != 0 {
+				// Skip stab debug info.
+				continue
+			}
+			sym := symbol{Name: s.Name, Value: s.Value}
+			i := sort.Search(len(addrs), func(x int) bool { return addrs[x] > s.Value })
+			if i < len(addrs) {
+				sym.Size = addrs[i] - s.Value
+			}
+			syms = append(syms, sym)
+		}
+
+		for _, sym := range syms {
+			m.symtab.table[sym.Name] = sym
+		}
+	})
+	return m.symtab.err
+}
+
+func (m *machoFile) hasSymbolTable() (bool, error) {
+	return m.file.Symtab != nil, nil
+}
+
+func (m *machoFile) getSymbol(name string) (uint64, uint64, error) {
+	err := m.initSymtab()
+	if err != nil {
+		return 0, 0, err
+	}
+	sym, ok := m.symtab.table[name]
+	if !ok {
+		return 0, 0, ErrSymbolNotFound
+	}
+	return sym.Value, sym.Size, nil
 }
 
 func (m *machoFile) getParsedFile() any {

--- a/macho.go
+++ b/macho.go
@@ -84,10 +84,6 @@ func (m *machoFile) initSymtab() map[string]Symbol {
 	return symm
 }
 
-func (m *machoFile) hasSymbolTable() (bool, error) {
-	return m.file.Symtab != nil, nil
-}
-
 func (m *machoFile) getSymbol(name string) (uint64, uint64, error) {
 	sym, ok := m.getsymtab()[name]
 	if !ok {

--- a/moduledata.go
+++ b/moduledata.go
@@ -283,9 +283,9 @@ func extractModuledata(f *GoFile) (moduledata, error) {
 	}
 
 	// if we can get the moduledata addr from the symbol, we have no need to search
-	addr, _, err := f.fh.getSymbol("runtime.firstmoduledata")
+	sym, err := f.fh.getSymbol("runtime.firstmoduledata")
 	if err == nil {
-		off = int(addr - secAddr)
+		off = int(sym.Value - secAddr)
 		goto load
 	}
 

--- a/moduledata.go
+++ b/moduledata.go
@@ -283,12 +283,10 @@ func extractModuledata(f *GoFile) (moduledata, error) {
 	}
 
 	// if we can get the moduledata addr from the symbol, we have no need to search
-	if ok, err := f.fh.hasSymbolTable(); ok && err == nil {
-		addr, _, err := f.fh.getSymbol("runtime.firstmoduledata")
-		if err == nil {
-			off = int(addr - secAddr)
-			goto load
-		}
+	addr, _, err := f.fh.getSymbol("runtime.firstmoduledata")
+	if err == nil {
+		off = int(addr - secAddr)
+		goto load
 	}
 
 	err = f.initPclntab()

--- a/moduledata.go
+++ b/moduledata.go
@@ -242,6 +242,10 @@ func pickVersionedModuleData(info *FileInfo) (modulable, error) {
 		bits = 64
 	}
 
+	if info.goversion == nil {
+		return nil, ErrNoGoVersionFound
+	}
+
 	ver := gover.Parse(extern.StripGo(info.goversion.Name))
 	zero := gover.Version{}
 	if ver == zero {

--- a/moduledata.go
+++ b/moduledata.go
@@ -283,7 +283,7 @@ func extractModuledata(fileInfo *FileInfo, f fileHandler) (moduledata, error) {
 	}
 
 	// if we can get the moduledata addr from the symbol, we have no need to search
-	if ok, err := f.hasSymbolTable(); err == nil && ok {
+	if ok, err := f.hasSymbolTable(); ok && err == nil {
 		addr, _, err := f.getSymbol("runtime.firstmoduledata")
 		if err == nil {
 			off = int(addr - secAddr)

--- a/pclntab.go
+++ b/pclntab.go
@@ -35,8 +35,6 @@ func searchSectionForTab(secData []byte, order binary.ByteOrder) ([]byte, error)
 	// First check for the current magic used. If this fails, it could be
 	// an older version. So check for the old header.
 MagicLoop:
-	for _, magic := range [][]byte{pclntab120magic, pclntab118magic, pclntab116magic, pclntab12magic} {
-		off := bytes.LastIndex(secData, magic)
 	for _, magic := range []uint32{gopclntab120magic, gopclntab118magic, gopclntab116magic, gopclntab12magic} {
 		bMagic := make([]byte, 6) // 4 bytes for the magic, 2 bytes for padding.
 		order.PutUint32(bMagic, magic)

--- a/pe.go
+++ b/pe.go
@@ -173,41 +173,7 @@ func (p *peFile) moduledataSection() string {
 	return ".data"
 }
 
-func (p *peFile) symbolData(start, end string) (uint64, uint64, []byte) {
-	var ssym, esym *pe.Symbol
-	for _, s := range p.file.Symbols {
-		if s.Name == start {
-			ssym = s
-		} else if s.Name == end {
-			esym = s
-		}
-		if ssym != nil && esym != nil {
-			break
-		}
-	}
-	if ssym == nil || esym == nil {
-		return 0, 0, nil
-	}
-	if ssym.SectionNumber != esym.SectionNumber {
-		return 0, 0, nil
-	}
-	sect := p.file.Sections[ssym.SectionNumber-1]
-	data, err := sect.Data()
-	if err != nil {
-		return 0, 0, nil
-	}
-	base := p.imageBase + uint64(sect.VirtualAddress)
-	return base + uint64(ssym.Value), base + uint64(esym.Value), data[ssym.Value:esym.Value]
-}
-
 func (p *peFile) getPCLNTABData() (uint64, []byte, error) {
-	if ok, err := p.hasSymbolTable(); ok && err == nil {
-		start, _, data := p.symbolData("runtime.pclntab", "runtime.epclntab")
-		if data != nil && start != 0 {
-			return start, data, nil
-		}
-	}
-
 	for _, v := range []string{".rdata", ".text"} {
 		sec := p.file.Section(v)
 		if sec == nil {

--- a/pe.go
+++ b/pe.go
@@ -202,7 +202,7 @@ func (p *peFile) symbolData(start, end string) (uint64, uint64, []byte) {
 func (p *peFile) getPCLNTABData() (uint64, []byte, error) {
 	if ok, err := p.hasSymbolTable(); ok && err == nil {
 		start, _, data := p.symbolData("runtime.pclntab", "runtime.epclntab")
-		if data != nil {
+		if data != nil && start != 0 {
 			return start, data, nil
 		}
 	}

--- a/pe.go
+++ b/pe.go
@@ -196,7 +196,8 @@ func (p *peFile) symbolData(start, end string) (uint64, uint64, []byte) {
 	if err != nil {
 		return 0, 0, nil
 	}
-	return p.imageBase + uint64(ssym.Value), p.imageBase + uint64(esym.Value), data[ssym.Value:esym.Value]
+	base := p.imageBase + uint64(sect.VirtualAddress)
+	return base + uint64(ssym.Value), base + uint64(esym.Value), data[ssym.Value:esym.Value]
 }
 
 func (p *peFile) getPCLNTABData() (uint64, []byte, error) {

--- a/pe.go
+++ b/pe.go
@@ -25,14 +25,14 @@ import (
 	"fmt"
 	"os"
 	"slices"
-	"sort"
+	"sync"
 )
 
 func openPE(fp string) (peF *peFile, err error) {
 	// Parsing by the file by debug/pe can panic if the PE file is malformed.
 	// To prevent a crash, we recover the panic and return it as an error
 	// instead.
-	go func() {
+	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("error when processing PE file, probably corrupt: %s", r)
 		}
@@ -62,7 +62,8 @@ func openPE(fp string) (peF *peFile, err error) {
 		return
 	}
 
-	peF = &peFile{file: f, osFile: osFile, imageBase: imageBase, symtab: newSymbolTableOnce()}
+	peF = &peFile{file: f, osFile: osFile, imageBase: imageBase}
+	peF.getsymtab = sync.OnceValues(peF.initSymTab)
 	return
 }
 
@@ -72,64 +73,63 @@ type peFile struct {
 	file      *pe.File
 	osFile    *os.File
 	imageBase uint64
-	symtab    *symbolTableOnce
+	getsymtab func() (map[string]Symbol, error)
 }
 
-func (p *peFile) initSymTab() error {
-	p.symtab.Do(func() {
-		var addrs []uint64
+func (p *peFile) initSymTab() (map[string]Symbol, error) {
+	var addrs []uint64
 
-		var syms []Symbol
-		for _, s := range p.file.Symbols {
-			const (
-				NUndef = 0  // An undefined (extern) symbol
-				NAbs   = -1 // An absolute symbol (e_value is a constant, not an address)
-				NDebug = -2 // A debugging symbol
-			)
-			sym := Symbol{Name: s.Name, Value: uint64(s.Value), Size: 0}
-			switch s.SectionNumber {
-			case NUndef, NAbs, NDebug: // do nothing
-			default:
-				if s.SectionNumber < 0 || len(p.file.Sections) < int(s.SectionNumber) {
-					p.symtab.err = fmt.Errorf("invalid section number in symbol table")
-					return
-				}
-				sect := p.file.Sections[s.SectionNumber-1]
-				sym.Value += p.imageBase + uint64(sect.VirtualAddress)
+	var syms []Symbol
+	for _, s := range p.file.Symbols {
+		const (
+			NUndef = 0  // An undefined (extern) symbol
+			NAbs   = -1 // An absolute symbol (e_value is a constant, not an address)
+			NDebug = -2 // A debugging symbol
+		)
+		sym := Symbol{Name: s.Name, Value: uint64(s.Value), Size: 0}
+		switch s.SectionNumber {
+		case NUndef, NAbs, NDebug: // do nothing
+		default:
+			if s.SectionNumber < 0 || len(p.file.Sections) < int(s.SectionNumber) {
+				return nil, fmt.Errorf("invalid section number in symbol table")
 			}
-			syms = append(syms, sym)
-			addrs = append(addrs, sym.Value)
+			sect := p.file.Sections[s.SectionNumber-1]
+			sym.Value += p.imageBase + uint64(sect.VirtualAddress)
 		}
+		syms = append(syms, sym)
+		addrs = append(addrs, sym.Value)
+	}
 
-		slices.Sort(addrs)
-		for i := range syms {
-			j := sort.Search(len(addrs), func(x int) bool { return addrs[x] > syms[i].Value })
-			if j < len(addrs) {
-				syms[i].Size = addrs[j] - syms[i].Value
-			}
+	slices.Sort(addrs)
+	for i := range syms {
+		j, found := slices.BinarySearch(addrs, syms[i].Value)
+		if found {
+			syms[i].Size = addrs[j] - syms[i].Value
 		}
+	}
 
-		for _, sym := range syms {
-			p.symtab.table[sym.Name] = sym
-		}
-	})
-	return p.symtab.err
+	symm := make(map[string]Symbol)
+	for _, sym := range syms {
+		symm[sym.Name] = sym
+	}
+
+	return symm, nil
 }
 
 func (p *peFile) hasSymbolTable() (bool, error) {
-	err := p.initSymTab()
+	symm, err := p.getsymtab()
 	if err != nil {
 		return false, err
 	}
-	return len(p.symtab.table) > 0, nil
+	return len(symm) > 0, nil
 }
 
 func (p *peFile) getSymbol(name string) (uint64, uint64, error) {
-	err := p.initSymTab()
+	symm, err := p.getsymtab()
 	if err != nil {
 		return 0, 0, err
 	}
-	sym, ok := p.symtab.table[name]
+	sym, ok := symm[name]
 	if !ok {
 		return 0, 0, ErrSymbolNotFound
 	}

--- a/pe.go
+++ b/pe.go
@@ -114,14 +114,6 @@ func (p *peFile) initSymTab() (map[string]Symbol, error) {
 	return symm, nil
 }
 
-func (p *peFile) hasSymbolTable() (bool, error) {
-	symm, err := p.getsymtab()
-	if err != nil {
-		return false, err
-	}
-	return len(symm) > 0, nil
-}
-
 func (p *peFile) getSymbol(name string) (uint64, uint64, error) {
 	symm, err := p.getsymtab()
 	if err != nil {

--- a/pe.go
+++ b/pe.go
@@ -173,7 +173,40 @@ func (p *peFile) moduledataSection() string {
 	return ".data"
 }
 
+func (p *peFile) symbolData(start, end string) (uint64, uint64, []byte) {
+	var ssym, esym *pe.Symbol
+	for _, s := range p.file.Symbols {
+		if s.Name == start {
+			ssym = s
+		} else if s.Name == end {
+			esym = s
+		}
+		if ssym != nil && esym != nil {
+			break
+		}
+	}
+	if ssym == nil || esym == nil {
+		return 0, 0, nil
+	}
+	if ssym.SectionNumber != esym.SectionNumber {
+		return 0, 0, nil
+	}
+	sect := p.file.Sections[ssym.SectionNumber-1]
+	data, err := sect.Data()
+	if err != nil {
+		return 0, 0, nil
+	}
+	return p.imageBase + uint64(ssym.Value), p.imageBase + uint64(esym.Value), data[ssym.Value:esym.Value]
+}
+
 func (p *peFile) getPCLNTABData() (uint64, []byte, error) {
+	if ok, err := p.hasSymbolTable(); ok && err == nil {
+		start, _, data := p.symbolData("runtime.pclntab", "runtime.epclntab")
+		if data != nil {
+			return start, data, nil
+		}
+	}
+
 	for _, v := range []string{".rdata", ".text"} {
 		sec := p.file.Section(v)
 		if sec == nil {

--- a/pe.go
+++ b/pe.go
@@ -114,16 +114,16 @@ func (p *peFile) initSymTab() (map[string]Symbol, error) {
 	return symm, nil
 }
 
-func (p *peFile) getSymbol(name string) (uint64, uint64, error) {
+func (p *peFile) getSymbol(name string) (Symbol, error) {
 	symm, err := p.getsymtab()
 	if err != nil {
-		return 0, 0, err
+		return Symbol{}, err
 	}
 	sym, ok := symm[name]
 	if !ok {
-		return 0, 0, ErrSymbolNotFound
+		return Symbol{}, ErrSymbolNotFound
 	}
-	return sym.Value, sym.Size, nil
+	return sym, nil
 }
 
 func (p *peFile) getParsedFile() any {

--- a/pe.go
+++ b/pe.go
@@ -62,7 +62,7 @@ func openPE(fp string) (peF *peFile, err error) {
 		return
 	}
 
-	peF = &peFile{file: f, osFile: osFile, imageBase: imageBase}
+	peF = &peFile{file: f, osFile: osFile, imageBase: imageBase, symtab: newSymbolTableOnce()}
 	return
 }
 

--- a/pe.go
+++ b/pe.go
@@ -79,14 +79,14 @@ func (p *peFile) initSymTab() error {
 	p.symtab.Do(func() {
 		var addrs []uint64
 
-		var syms []symbol
+		var syms []Symbol
 		for _, s := range p.file.Symbols {
 			const (
 				NUndef = 0  // An undefined (extern) symbol
 				NAbs   = -1 // An absolute symbol (e_value is a constant, not an address)
 				NDebug = -2 // A debugging symbol
 			)
-			sym := symbol{Name: s.Name, Value: uint64(s.Value), Size: 0}
+			sym := Symbol{Name: s.Name, Value: uint64(s.Value), Size: 0}
 			switch s.SectionNumber {
 			case NUndef, NAbs, NDebug: // do nothing
 			default:

--- a/slow_test.go
+++ b/slow_test.go
@@ -380,6 +380,9 @@ func buildTestResource(body, goos, arch string, pie, stripped bool, wg *sync.Wai
 	args := []string{"build", "-o", exe, "-ldflags", ldFlags}
 	if pie {
 		args = append(args, "-buildmode=pie")
+	} else {
+		// Windows use pie by default
+		args = append(args, "-buildmode=exe")
 	}
 	args = append(args, src)
 

--- a/slow_test.go
+++ b/slow_test.go
@@ -157,8 +157,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestOpenAndCloseFile(t *testing.T) {
-	getMatrix(t, nil, nil, "open", func(tt *testing.T, exe string) {
-		a := assert.New(tt)
+	getMatrix(t, nil, nil, "open", func(t *testing.T, exe string) {
+		a := assert.New(t)
 
 		f, err := Open(exe)
 		a.NoError(err)
@@ -168,9 +168,9 @@ func TestOpenAndCloseFile(t *testing.T) {
 }
 
 func TestGetPackages(t *testing.T) {
-	getMatrix(t, nil, nil, "getPackages", func(tt *testing.T, exe string) {
-		a := assert.New(tt)
-		r := require.New(tt)
+	getMatrix(t, nil, nil, "getPackages", func(t *testing.T, exe string) {
+		a := assert.New(t)
+		r := require.New(t)
 
 		f, err := Open(exe)
 		r.NoError(err)
@@ -224,7 +224,7 @@ func TestGetPackages(t *testing.T) {
 }
 
 func TestGetTypesFromDynamicBuiltResources(t *testing.T) {
-	getMatrix(t, nil, nil, "getTypes", func(tt *testing.T, exe string) {
+	getMatrix(t, nil, nil, "getTypes", func(t *testing.T, exe string) {
 		a := assert.New(t)
 		r := require.New(t)
 		f, err := Open(exe)

--- a/slow_test.go
+++ b/slow_test.go
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //go:build slow_test
-// +build slow_test
 
 package gore
 
@@ -47,66 +46,103 @@ var dynResources = []struct {
 var dynResourceFiles *testFiles
 
 type testFiles struct {
-	files   map[string]string
-	filesMu sync.RWMutex
+	files sync.Map
 }
 
 func (f *testFiles) get(os, arch string, pie, stripped bool) string {
-	f.filesMu.Lock()
-	defer f.filesMu.Unlock()
+	name := os + "-" + arch
 	if pie {
-		return f.files[os+arch+"-pie"]
+		name += "-pie"
 	}
 	if !stripped {
-		return f.files[os+arch+"-nostrip"]
+		name += "-nostrip"
 	}
-	return f.files[os+arch]
+	exe, ok := f.files.Load(name)
+	if !ok {
+		return ""
+	}
+	return exe.(string)
+}
+
+// pass nil to check means all combinations
+func getMatrix(t *testing.T, checkPie, checkStrip *bool, prefix string, cb func(*testing.T, string)) {
+	t.Helper()
+	for _, r := range dynResources {
+		var pieCases []bool
+		if checkPie != nil {
+			pieCases = append(pieCases, *checkPie)
+		} else {
+			pieCases = append(pieCases, true, false)
+		}
+		for _, pie := range pieCases {
+			var strippedCases []bool
+			if checkStrip != nil {
+				strippedCases = append(strippedCases, *checkStrip)
+			} else {
+				strippedCases = append(strippedCases, true, false)
+			}
+			for _, stripped := range strippedCases {
+				exe := dynResourceFiles.get(r.os, r.arch, pie, stripped)
+				name := r.os + "-" + r.arch
+				if pie {
+					name += "-pie"
+				}
+				if !stripped {
+					name += "-nostrip"
+				}
+				t.Run(prefix+"-"+name, func(tt *testing.T) {
+					tt.Parallel()
+					if exe == "" {
+						tt.Skip("no executable available")
+					}
+					cb(tt, exe)
+				})
+			}
+		}
+
+	}
 }
 
 func TestMain(m *testing.M) {
 	fmt.Println("Creating test resources, this can take some time...")
 	var tmpDirs []string
-	fs := make(map[string]string)
 
 	resultChan := make(chan buildResult)
 	wg := &sync.WaitGroup{}
 
+	dynResourceFiles = &testFiles{files: sync.Map{}}
+
 	go func() {
 		for r := range resultChan {
 			tmpDirs = append(tmpDirs, r.dir)
-			name := r.os + r.arch
+			name := r.os + "-" + r.arch
 			if r.pie {
 				name += "-pie"
 			}
 			if !r.strip {
 				name += "-nostrip"
 			}
-			fs[name] = r.exe
+			dynResourceFiles.files.Store(name, r.exe)
 		}
 	}()
 
 	for _, r := range dynResources {
 		fmt.Printf("Building resource file for %s_%s\n", r.os, r.arch)
-		wg.Add(1)
-		go buildTestResource(testresourcesrc, r.os, r.arch, false, true, wg, resultChan)
 
-		// Build a PIE version of the file. Not all host systems, particular macOS, appears to be able
-		// to compile a PIE build of linux-386. In this case, we skip this combination.
-		if !(r.arch == "386" && r.os == "linux") {
-			wg.Add(1)
-			go buildTestResource(testresourcesrc, r.os, r.arch, true, true, wg, resultChan)
+		for _, pie := range []bool{false, true} {
+			for _, stripped := range []bool{false, true} {
+				if pie && r.arch == "386" && r.os == "linux" {
+					// seems impossible
+					continue
+				}
+				wg.Add(1)
+				go buildTestResource(testresourcesrc, r.os, r.arch, pie, stripped, wg, resultChan)
+			}
 		}
-
-		// build unstripped binary; needs separate source file with reference to GOROOT
-		// for test trying to access it to pass
-		wg.Add(1)
-		go buildTestResource(nostripSrc, r.os, r.arch, false, false, wg, resultChan)
 	}
 
 	wg.Wait()
 	close(resultChan)
-
-	dynResourceFiles = &testFiles{files: fs}
 
 	fmt.Println("Launching tests")
 	code := m.Run()
@@ -121,200 +157,94 @@ func TestMain(m *testing.M) {
 }
 
 func TestOpenAndCloseFile(t *testing.T) {
-	for _, test := range dynResources {
-		t.Run("open_"+test.os+"-"+test.arch, func(t *testing.T) {
-			assert := assert.New(t)
-			exe := dynResourceFiles.get(test.os, test.arch, false, true)
+	getMatrix(t, nil, nil, "open", func(tt *testing.T, exe string) {
+		a := assert.New(tt)
 
-			f, err := Open(exe)
-			assert.NoError(err)
-			assert.NotNil(f)
-			assert.NoError(f.Close())
-		})
-
-		t.Run("open_"+test.os+"-"+test.arch+"-pie", func(t *testing.T) {
-			assert := assert.New(t)
-			exe := dynResourceFiles.get(test.os, test.arch, true, true)
-			if exe == "" {
-				t.Skip("no PIE available")
-			}
-
-			f, err := Open(exe)
-			assert.NoError(err)
-			assert.NotNil(f)
-			assert.NoError(f.Close())
-		})
-	}
+		f, err := Open(exe)
+		a.NoError(err)
+		a.NotNil(f)
+		a.NoError(f.Close())
+	})
 }
 
 func TestGetPackages(t *testing.T) {
-	for _, test := range dynResources {
-		t.Run("open_"+test.os+"-"+test.arch, func(t *testing.T) {
-			assert := assert.New(t)
-			require := require.New(t)
-			exe := dynResourceFiles.get(test.os, test.arch, false, true)
-			if exe == "" {
-				t.Skip("no PIE available")
+	getMatrix(t, nil, nil, "getPackages", func(tt *testing.T, exe string) {
+		a := assert.New(tt)
+		r := require.New(tt)
+
+		f, err := Open(exe)
+		r.NoError(err)
+		r.NotNil(f)
+		defer f.Close()
+
+		std, err := f.GetSTDLib()
+		a.NoError(err)
+		a.NotEmpty(std, "Should have a list of standard library packages.")
+
+		_, err = f.GetGeneratedPackages()
+		a.NoError(err)
+		// XXX: This check appears to be unstable. Sometimes files for unknown reason.
+		// assert.NotEmpty(gen, "Should have a list of generated packages.")
+
+		ven, err := f.GetVendors()
+		a.NoError(err)
+		a.Empty(ven, "Should not have a list of vendor packages.")
+
+		_, err = f.GetUnknown()
+		a.NoError(err)
+		// XXX: This check appears to be unstable. Sometimes files for unknown reason.
+		// assert.Empty(unk, "Should not have a list of unknown packages")
+
+		pkgs, err := f.GetPackages()
+		a.NoError(err)
+
+		var mainpkg *Package
+		for _, p := range pkgs {
+			if p.Name == "main" {
+				mainpkg = p
+				break
 			}
+		}
 
-			f, err := Open(exe)
-			require.NoError(err)
-			require.NotNil(f)
-			defer f.Close()
-
-			std, err := f.GetSTDLib()
-			assert.NoError(err)
-			assert.NotEmpty(std, "Should have a list of standard library packages.")
-
-			_, err = f.GetGeneratedPackages()
-			assert.NoError(err)
-			// XXX: This check appears to be unstable. Sometimes files for unknown reason.
-			// assert.NotEmpty(gen, "Should have a list of generated packages.")
-
-			ven, err := f.GetVendors()
-			assert.NoError(err)
-			assert.Empty(ven, "Should not have a list of vendor packages.")
-
-			_, err = f.GetUnknown()
-			assert.NoError(err)
-			// XXX: This check appears to be unstable. Sometimes files for unknown reason.
-			// assert.Empty(unk, "Should not have a list of unknown packages")
-
-			pkgs, err := f.GetPackages()
-			assert.NoError(err)
-
-			var mainpkg *Package
-			for _, p := range pkgs {
-				if p.Name == "main" {
-					mainpkg = p
-					break
-				}
+		mainPackageFound := false
+		getDataFuncFound := false
+		a.NotNil(mainpkg, "Should include main package")
+		for _, f := range mainpkg.Functions {
+			if f.Name == "main" {
+				mainPackageFound = true
+			} else if f.Name == "getData" {
+				getDataFuncFound = true
+			} else {
+				a.Fail("Unexpected function")
 			}
-
-			mp := false
-			gd := false
-			assert.NotNil(mainpkg, "Should include main package")
-			for _, f := range mainpkg.Functions {
-				if f.Name == "main" {
-					mp = true
-				} else if f.Name == "getData" {
-					gd = true
-				} else {
-					assert.Fail("Unexpected function")
-				}
-			}
-			assert.True(mp, "No main function found")
-			assert.True(gd, "getData function not found")
-		})
-
-		t.Run("open_"+test.os+"-"+test.arch+"-pie", func(t *testing.T) {
-			assert := assert.New(t)
-			require := require.New(t)
-			exe := dynResourceFiles.get(test.os, test.arch, false, true)
-			f, err := Open(exe)
-			require.NoError(err)
-			require.NotNil(f)
-			defer f.Close()
-
-			std, err := f.GetSTDLib()
-			assert.NoError(err)
-			assert.NotEmpty(std, "Should have a list of standard library packages.")
-
-			_, err = f.GetGeneratedPackages()
-			assert.NoError(err)
-			// XXX: This check appears to be unstable. Sometimes files for unknown reason.
-			// assert.NotEmpty(gen, "Should have a list of generated packages.")
-
-			ven, err := f.GetVendors()
-			assert.NoError(err)
-			assert.Empty(ven, "Should not have a list of vendor packages.")
-
-			_, err = f.GetUnknown()
-			assert.NoError(err)
-			// XXX: This check appears to be unstable. Sometimes files for unknown reason.
-			// assert.Empty(unk, "Should not have a list of unknown packages")
-
-			pkgs, err := f.GetPackages()
-			assert.NoError(err)
-
-			var mainpkg *Package
-			for _, p := range pkgs {
-				if p.Name == "main" {
-					mainpkg = p
-					break
-				}
-			}
-
-			mp := false
-			gd := false
-			assert.NotNil(mainpkg, "Should include main package")
-			for _, f := range mainpkg.Functions {
-				if f.Name == "main" {
-					mp = true
-				} else if f.Name == "getData" {
-					gd = true
-				} else {
-					assert.Fail("Unexpected function")
-				}
-			}
-			assert.True(mp, "No main function found")
-			assert.True(gd, "getData function not found")
-		})
-	}
+		}
+		a.True(mainPackageFound, "No main function found")
+		a.True(getDataFuncFound, "getData function not found")
+	})
 }
 
 func TestGetTypesFromDynamicBuiltResources(t *testing.T) {
-	for _, test := range dynResources {
-		t.Run("open_"+test.os+"-"+test.arch, func(t *testing.T) {
-			assert := assert.New(t)
-			require := require.New(t)
-			exe := dynResourceFiles.get(test.os, test.arch, false, true)
-			f, err := Open(exe)
-			require.NoError(err)
-			require.NotNil(f)
-			defer f.Close()
+	getMatrix(t, nil, nil, "getTypes", func(tt *testing.T, exe string) {
+		a := assert.New(t)
+		r := require.New(t)
+		f, err := Open(exe)
+		r.NoError(err)
+		r.NotNil(f)
+		defer f.Close()
 
-			typs, err := f.GetTypes()
-			require.NoError(err)
+		typs, err := f.GetTypes()
+		r.NoError(err)
 
-			var stringer *GoType
-			for _, t := range typs {
-				if t.PackagePath == "runtime" && t.Name == "runtime.g" {
-					stringer = t
-					break
-				}
+		var stringer *GoType
+		for _, t := range typs {
+			if t.PackagePath == "runtime" && t.Name == "runtime.g" {
+				stringer = t
+				break
 			}
+		}
 
-			assert.NotNil(stringer, "the g type from runtime not found")
-		})
-
-		t.Run("open_"+test.os+"-"+test.arch+"-pie", func(t *testing.T) {
-			assert := assert.New(t)
-			require := require.New(t)
-			exe := dynResourceFiles.get(test.os, test.arch, true, true)
-			if exe == "" {
-				t.Skip(("PIE file not available"))
-			}
-
-			f, err := Open(exe)
-			require.NoError(err)
-			require.NotNil(f)
-			defer f.Close()
-
-			typs, err := f.GetTypes()
-			require.NoError(err)
-
-			var stringer *GoType
-			for _, t := range typs {
-				if t.PackagePath == "runtime" && t.Name == "runtime.g" {
-					stringer = t
-					break
-				}
-			}
-
-			assert.NotNil(stringer, "the g type from runtime not found")
-		})
-	}
+		a.NotNil(stringer, "the g type from runtime not found")
+	})
 }
 
 func TestGetCompilerVersion(t *testing.T) {
@@ -323,174 +253,91 @@ func TestGetCompilerVersion(t *testing.T) {
 
 	// If the version could not be resolved, the version is new
 	// and the library doesn't know about it. Use the version string
-	// to created a new version.
+	// to create a new version.
 	if expectedVersion == nil {
 		expectedVersion = &GoVersion{Name: testVersion}
 	}
 
-	for _, test := range dynResources {
-		t.Run("parsing_"+test.os+"-"+test.arch, func(t *testing.T) {
-			assert := assert.New(t)
-			require := require.New(t)
-			exe := dynResourceFiles.get(test.os, test.arch, false, true)
-			f, err := Open(exe)
-			require.NoError(err)
-			require.NotNil(f)
-			defer f.Close()
+	getMatrix(t, nil, nil, "compiler-version", func(t *testing.T, exe string) {
+		a := assert.New(t)
+		r := require.New(t)
+		f, err := Open(exe)
+		r.NoError(err)
+		r.NotNil(f)
+		defer f.Close()
 
-			// Test
-			version, err := f.GetCompilerVersion()
-			assert.NoError(err)
-			assert.Equal(expectedVersion, version)
-		})
-
-		t.Run("parsing_"+test.os+"-"+test.arch+"-pie", func(t *testing.T) {
-			assert := assert.New(t)
-			require := require.New(t)
-			exe := dynResourceFiles.get(test.os, test.arch, true, true)
-			if exe == "" {
-				t.Skip("no PIE available")
-			}
-
-			f, err := Open(exe)
-			require.NoError(err)
-			require.NotNil(f)
-			defer f.Close()
-
-			// Test
-			version, err := f.GetCompilerVersion()
-			assert.NoError(err)
-			assert.Equal(expectedVersion, version)
-		})
-	}
+		// Test
+		version, err := f.GetCompilerVersion()
+		a.NoError(err)
+		a.Equal(expectedVersion, version)
+	})
 }
 
 func TestGetBuildID(t *testing.T) {
-	for _, test := range dynResources {
-		t.Run("buildID_"+test.os+"-"+test.arch, func(t *testing.T) {
-			assert := assert.New(t)
-			require := require.New(t)
-			exe := dynResourceFiles.get(test.os, test.arch, false, true)
-			f, err := Open(exe)
-			require.NoError(err)
-			require.NotNil(f)
-			defer f.Close()
+	getMatrix(t, nil, nil, "buildID", func(t *testing.T, exe string) {
+		a := assert.New(t)
+		r := require.New(t)
+		f, err := Open(exe)
+		r.NoError(err)
+		r.NotNil(f)
+		defer f.Close()
 
-			assert.Equal(fixedBuildID, f.BuildID, "BuildID extracted doesn't match expected value.")
-		})
-
-		t.Run("buildID_"+test.os+"-"+test.arch+"-pie", func(t *testing.T) {
-			assert := assert.New(t)
-			require := require.New(t)
-			exe := dynResourceFiles.get(test.os, test.arch, true, true)
-			if exe == "" {
-				t.Skip("no PIE available")
-			}
-
-			f, err := Open(exe)
-			require.NoError(err)
-			require.NotNil(f)
-			defer f.Close()
-
-			assert.Equal(fixedBuildID, f.BuildID, "BuildID extracted doesn't match expected value.")
-		})
-	}
+		a.Equal(fixedBuildID, f.BuildID, "BuildID extracted doesn't match expected value.")
+	})
 }
 
 func TestSourceInfo(t *testing.T) {
-	for _, test := range dynResources {
-		t.Run("buildID_"+test.os+"-"+test.arch, func(t *testing.T) {
-			assert := assert.New(t)
-			require := require.New(t)
-			exe := dynResourceFiles.get(test.os, test.arch, false, true)
-			f, err := Open(exe)
-			require.NoError(err)
-			require.NotNil(f)
-			defer f.Close()
+	getMatrix(t, nil, nil, "sourceInfo", func(t *testing.T, exe string) {
+		a := assert.New(t)
+		r := require.New(t)
+		f, err := Open(exe)
+		r.NoError(err)
+		r.NotNil(f)
+		defer f.Close()
 
-			var testFn *Function
-			pkgs, err := f.GetPackages()
-			require.NoError(err)
-			for _, pkg := range pkgs {
-				if pkg.Name != "main" {
+		var testFn *Function
+		pkgs, err := f.GetPackages()
+		r.NoError(err)
+		for _, pkg := range pkgs {
+			if pkg.Name != "main" {
+				continue
+			}
+			for _, fn := range pkg.Functions {
+				if fn.Name != "getData" {
 					continue
 				}
-				for _, fn := range pkg.Functions {
-					if fn.Name != "getData" {
-						continue
-					}
-					testFn = fn
-					break
-				}
+				testFn = fn
+				break
 			}
-			require.NotNil(testFn)
+		}
+		r.NotNil(testFn)
 
-			file, start, end := f.SourceInfo(testFn)
+		file, start, end := f.SourceInfo(testFn)
 
-			assert.NotEqual(0, start)
-			assert.NotEqual(0, end)
-			assert.NotEqual("", file)
-		})
-
-		t.Run("buildID_"+test.os+"-"+test.arch+"-pie", func(t *testing.T) {
-			assert := assert.New(t)
-			require := require.New(t)
-			exe := dynResourceFiles.get(test.os, test.arch, true, true)
-			if exe == "" {
-				t.Skip("no PIE available")
-			}
-
-			f, err := Open(exe)
-			require.NoError(err)
-			require.NotNil(f)
-			defer f.Close()
-
-			var testFn *Function
-			pkgs, err := f.GetPackages()
-			require.NoError(err)
-			for _, pkg := range pkgs {
-				if pkg.Name != "main" {
-					continue
-				}
-				for _, fn := range pkg.Functions {
-					if fn.Name != "getData" {
-						continue
-					}
-					testFn = fn
-					break
-				}
-			}
-			require.NotNil(testFn)
-
-			file, start, end := f.SourceInfo(testFn)
-
-			assert.NotEqual(0, start)
-			assert.NotEqual(0, end)
-			assert.NotEqual("", file)
-		})
-	}
+		a.NotEqual(0, start)
+		a.NotEqual(0, end)
+		a.NotEqual("", file)
+	})
 }
 
 func TestDwarfString(t *testing.T) {
-	for _, test := range dynResources {
-		t.Run("dwarfString_"+test.os+"-"+test.arch, func(t *testing.T) {
-			require := require.New(t)
+	noStrip := false
+	getMatrix(t, nil, &noStrip, "dwarfString", func(t *testing.T, exe string) {
+		r := require.New(t)
 
-			exe := dynResourceFiles.get(test.os, test.arch, false, false)
-			f, err := Open(exe)
-			require.NoError(err)
-			require.NotNil(f)
-			defer f.Close()
+		f, err := Open(exe)
+		r.NoError(err)
+		r.NotNil(f)
+		defer f.Close()
 
-			gover, ok := getBuildVersionFromDwarf(f.fh)
-			require.True(ok)
-			require.Equal(gover, runtime.Version())
+		gover, ok := getBuildVersionFromDwarf(f.fh)
+		r.True(ok)
+		r.Equal(gover, runtime.Version())
 
-			goroot, ok := getGoRootFromDwarf(f.fh)
-			require.True(ok)
-			require.Equal(goroot, runtime.GOROOT())
-		})
-	}
+		goroot, ok := getGoRootFromDwarf(f.fh)
+		r.True(ok)
+		r.Equal(goroot, runtime.GOROOT())
+	})
 }
 
 type buildResult struct {
@@ -521,8 +368,8 @@ func buildTestResource(body, goos, arch string, pie, stripped bool, wg *sync.Wai
 	}
 
 	exe := filepath.Join(tmpdir, "a")
-	if pie {
-		exe = exe + "-pie"
+	if runtime.GOOS == "windows" {
+		exe += ".exe"
 	}
 
 	var ldFlags string

--- a/symbol.go
+++ b/symbol.go
@@ -6,10 +6,12 @@ import (
 
 var ErrSymbolNotFound = errors.New("symbol not found")
 
-// Symbol A primitive representation of a symbol.
+// Symbol A generic representation of [debug/elf.Symbol], [debug/pe.Symbol], and [debug/macho.Symbol].
 type Symbol struct {
-	Name  string // Name of the symbol.
-	Value uint64 // Value of the symbol.
+	// Name of the symbol.
+	Name string
+	// Value of the symbol.
+	Value uint64
 	// Size of the symbol. Only accurate on ELF files. For Mach-O and PE files, it was inferred by looking at the next symbol.
 	Size uint64
 }

--- a/symbol.go
+++ b/symbol.go
@@ -2,7 +2,6 @@ package gore
 
 import (
 	"errors"
-	"sync"
 )
 
 var ErrSymbolNotFound = errors.New("symbol not found")
@@ -13,14 +12,4 @@ type Symbol struct {
 	Value uint64 // Value of the symbol.
 	// Size of the symbol. Only accurate on ELF files. For Mach-O and PE files, it was inferred by looking at the next symbol.
 	Size uint64
-}
-
-type symbolTableOnce struct {
-	*sync.Once
-	table map[string]Symbol
-	err   error
-}
-
-func newSymbolTableOnce() *symbolTableOnce {
-	return &symbolTableOnce{Once: &sync.Once{}, table: make(map[string]Symbol)}
 }

--- a/symbol.go
+++ b/symbol.go
@@ -7,19 +7,20 @@ import (
 
 var ErrSymbolNotFound = errors.New("symbol not found")
 
-// symbol A primitive representation of a symbol.
-type symbol struct {
-	Name  string
-	Value uint64
-	Size  uint64
+// Symbol A primitive representation of a symbol.
+type Symbol struct {
+	Name  string // Name of the symbol.
+	Value uint64 // Value of the symbol.
+	// Size of the symbol. Only accurate on ELF files. For Mach-O and PE files, it was inferred by looking at the next symbol.
+	Size uint64
 }
 
 type symbolTableOnce struct {
 	*sync.Once
-	table map[string]symbol
+	table map[string]Symbol
 	err   error
 }
 
 func newSymbolTableOnce() *symbolTableOnce {
-	return &symbolTableOnce{Once: &sync.Once{}, table: make(map[string]symbol)}
+	return &symbolTableOnce{Once: &sync.Once{}, table: make(map[string]Symbol)}
 }

--- a/symbol.go
+++ b/symbol.go
@@ -1,0 +1,25 @@
+package gore
+
+import (
+	"errors"
+	"sync"
+)
+
+var ErrSymbolNotFound = errors.New("symbol not found")
+
+// symbol A primitive representation of a symbol.
+type symbol struct {
+	Name  string
+	Value uint64
+	Size  uint64
+}
+
+type symbolTableOnce struct {
+	*sync.Once
+	table map[string]symbol
+	err   error
+}
+
+func newSymbolTableOnce() *symbolTableOnce {
+	return &symbolTableOnce{Once: &sync.Once{}, table: make(map[string]symbol)}
+}


### PR DESCRIPTION
Add some symbol-based operations to speed things up where possible. Also add some methods to the platform file wrapper to support this.

Since we currently don't have binaries with symbol table, most of the testing was done in the slow_test. rewrite to make it run concurrently