### PR TITLE
Handle new moduledata section

### DIFF
--- a/elf.go
+++ b/elf.go
@@ -152,6 +152,10 @@ func (e *elfFile) getPCLNTABData() (uint64, []byte, error) {
 }
 
 func (e *elfFile) moduledataSection() string {
+	// In Go 1.26, the moduledata was moved to its own section.
+	if section := e.file.Section(".go.module"); section != nil {
+		return ".go.module"
+	}
 	return ".noptrdata"
 }
 

--- a/macho.go
+++ b/macho.go
@@ -174,6 +174,10 @@ func (m *machoFile) getPCLNTABData() (uint64, []byte, error) {
 }
 
 func (m *machoFile) moduledataSection() string {
+	// In Go 1.26, the moduledata was moved to its own section.
+	if section := m.file.Section("__DATA", "__go_module"); section != nil {
+		return "__go_module"
+	}
 	return "__noptrdata"
 }
 


### PR DESCRIPTION
In Go 1.26, the moduledata was given its own section in ELF and Mach-O files. This commit checks if the new section exist in the file. If not, it fall back to the old section name.

Part of #114 