### PR TITLE
fix: improve resilience of type parsing and moduledata extraction

### DIFF
--- a/elf.go
+++ b/elf.go
@@ -153,7 +153,8 @@ func (e *elfFile) getPCLNTABData() (uint64, []byte, error) {
 
 func (e *elfFile) moduledataSection() string {
 	// In Go 1.26, the moduledata was moved to its own section.
-	if section := e.file.Section(".go.module"); section != nil {
+	// Check Size > 0 because cgo binaries may have the section header but no data.
+	if section := e.file.Section(".go.module"); section != nil && section.Size > 0 {
 		return ".go.module"
 	}
 	return ".noptrdata"

--- a/fixup.go
+++ b/fixup.go
@@ -1,0 +1,246 @@
+package gore
+
+import (
+	"debug/elf"
+	"encoding/binary"
+
+	"github.com/blacktop/go-macho"
+)
+
+// pointerResolver resolves relocated pointer values in PIE binaries.
+// Implementations handle Mach-O chained fixups and ELF RELATIVE relocations.
+type pointerResolver interface {
+	// ResolvePointer returns the relocated value of a pointer stored at fileAddr.
+	// Non-pointer values are returned unchanged.
+	ResolvePointer(val uint64, fileAddr uint64) uint64
+}
+
+// newPointerResolver returns a resolver for the given file handler,
+// or nil if the binary has no pointer relocations to resolve.
+func newPointerResolver(fh fileHandler) pointerResolver {
+	if fh == nil {
+		return nil
+	}
+	switch f := fh.getParsedFile().(type) {
+	case *macho.File:
+		if fh.getFileInfo().WordSize != 8 {
+			return nil
+		}
+		return newMachoResolver(f)
+	case *elf.File:
+		if r := newElfResolver(f, fh.getFileInfo()); r != nil {
+			return r
+		}
+		return nil
+	}
+	return nil
+}
+
+// resolvePointer is a nil-safe helper that calls r.ResolvePointer if r is non-nil.
+func resolvePointer(r pointerResolver, val uint64, fileAddr uint64) uint64 {
+	if r == nil {
+		return val
+	}
+	return r.ResolvePointer(val, fileAddr)
+}
+
+// resolveBuffer resolves all word-sized slots in data where the resolver
+// unambiguously changes the value (i.e., raw != resolved). Used for moduledata
+// where fields mix pointers and non-pointer integers. Returns a new buffer.
+func resolveBuffer(r *machoResolver, data []byte, baseAddr uint64, wordSize int, order binary.ByteOrder) []byte {
+	if r == nil {
+		return data
+	}
+	resolved := make([]byte, len(data))
+	copy(resolved, data)
+	for i := 0; i+wordSize <= len(data); i += wordSize {
+		var raw uint64
+		if wordSize == 4 {
+			raw = uint64(order.Uint32(data[i:]))
+		} else {
+			raw = order.Uint64(data[i:])
+		}
+		val, err := r.mf.GetSlidPointerAtAddress(baseAddr + uint64(i))
+		if err != nil || val == raw {
+			continue
+		}
+		if val < r.imageBase {
+			val += r.imageBase
+		}
+		if wordSize == 4 {
+			order.PutUint32(resolved[i:], uint32(val))
+		} else {
+			order.PutUint64(resolved[i:], val)
+		}
+	}
+	return resolved
+}
+
+// findPointerValue scans word-sized slots looking for one resolving to targetAddr.
+func findPointerValue(r pointerResolver, secAddr uint64, secData []byte, targetAddr uint64, wordSize int, order binary.ByteOrder) int {
+	if r == nil {
+		return -1
+	}
+	for i := 0; i+wordSize <= len(secData); i += wordSize {
+		var raw uint64
+		if wordSize == 4 {
+			raw = uint64(order.Uint32(secData[i:]))
+		} else {
+			raw = order.Uint64(secData[i:])
+		}
+		if r.ResolvePointer(raw, secAddr+uint64(i)) == targetAddr {
+			return i
+		}
+	}
+	return -1
+}
+
+// --- Mach-O implementation ---
+
+type machoResolver struct {
+	mf        *macho.File
+	imageBase uint64
+	chained   bool
+}
+
+func newMachoResolver(mf *macho.File) *machoResolver {
+	return &machoResolver{
+		mf:        mf,
+		imageBase: machoImageBase(mf),
+		chained:   mf.HasDyldChainedFixups(),
+	}
+}
+
+func (r *machoResolver) ResolvePointer(val uint64, fileAddr uint64) uint64 {
+	if val == 0 {
+		return val
+	}
+	resolved, err := r.mf.GetSlidPointerAtAddress(fileAddr)
+	if err != nil {
+		return val
+	}
+	if resolved != val {
+		if resolved < r.imageBase {
+			resolved += r.imageBase
+		}
+		return resolved
+	}
+	// Chain-tail pointer: resolved == raw but may lack image base in chained fixup binaries.
+	if r.chained && resolved < r.imageBase && r.looksLikePointer(resolved) {
+		return resolved + r.imageBase
+	}
+	return val
+}
+
+func (r *machoResolver) looksLikePointer(val uint64) bool {
+	target := val + r.imageBase
+	for _, seg := range r.mf.Segments() {
+		if seg.Memsz > 0 && target >= seg.Addr && target < seg.Addr+seg.Memsz {
+			return true
+		}
+	}
+	return false
+}
+
+func machoImageBase(mf *macho.File) uint64 {
+	for _, seg := range mf.Segments() {
+		if seg.Name == "__TEXT" {
+			return seg.Addr
+		}
+	}
+	return 0
+}
+
+// --- ELF implementation ---
+
+// elfResolver resolves R_*_RELATIVE relocations using a prebuilt offset→addend map.
+type elfResolver struct {
+	relocs map[uint64]uint64 // file offset → resolved address (addend)
+}
+
+func newElfResolver(f *elf.File, fi *FileInfo) *elfResolver {
+	relocs := make(map[uint64]uint64)
+	is32 := fi.WordSize == 4
+
+	for _, s := range f.Sections {
+		if is32 && s.Type == elf.SHT_REL {
+			data, err := s.Data()
+			if err != nil {
+				continue
+			}
+			// 32-bit REL: 4-byte offset + 4-byte info, no addend.
+			// R_386_RELATIVE: final addr = base + *(offset). For static
+			// analysis base=0, so the value at the offset IS the address.
+			// We skip these since the file already contains the right value
+			// at base=0... actually no, the value in the file is the addend
+			// for REL entries. We need to just mark these offsets.
+			relType386Relative := uint32(8) // R_386_RELATIVE
+			for i := 0; i+8 <= len(data); i += 8 {
+				offset := uint64(fi.ByteOrder.Uint32(data[i:]))
+				info := fi.ByteOrder.Uint32(data[i+4:])
+				if info == relType386Relative {
+					// For R_386_RELATIVE with REL (no explicit addend),
+					// the addend is stored at the relocation target in the file.
+					// We read it from the file via getSectionDataFromAddress later.
+					// For now, mark with 0 as sentinel — we handle this in ResolvePointer.
+					relocs[offset] = 0
+				}
+			}
+		}
+
+		if s.Type == elf.SHT_RELA {
+			data, err := s.Data()
+			if err != nil {
+				continue
+			}
+			if is32 {
+				relType386Relative := uint32(8) // R_386_RELATIVE
+				for i := 0; i+12 <= len(data); i += 12 {
+					offset := uint64(fi.ByteOrder.Uint32(data[i:]))
+					info := fi.ByteOrder.Uint32(data[i+4:])
+					addend := uint64(int64(int32(fi.ByteOrder.Uint32(data[i+8:]))))
+					if info == relType386Relative {
+						relocs[offset] = addend
+					}
+				}
+			} else {
+				// 64-bit RELA: 8-byte offset + 8-byte info + 8-byte addend
+				var relTypeRelative uint32
+				switch f.Machine {
+				case elf.EM_X86_64:
+					relTypeRelative = uint32(elf.R_X86_64_RELATIVE)
+				case elf.EM_AARCH64:
+					relTypeRelative = uint32(elf.R_AARCH64_RELATIVE)
+				case elf.EM_386:
+					relTypeRelative = uint32(elf.R_386_RELATIVE)
+				default:
+					continue
+				}
+				for i := 0; i+24 <= len(data); i += 24 {
+					offset := fi.ByteOrder.Uint64(data[i:])
+					info := fi.ByteOrder.Uint64(data[i+8:])
+					addend := fi.ByteOrder.Uint64(data[i+16:])
+					if uint32(info&0xffffffff) == relTypeRelative {
+						relocs[offset] = addend
+					}
+				}
+			}
+		}
+	}
+
+	if len(relocs) == 0 {
+		return nil
+	}
+	return &elfResolver{relocs: relocs}
+}
+
+func (r *elfResolver) ResolvePointer(val uint64, fileAddr uint64) uint64 {
+	if addend, ok := r.relocs[fileAddr]; ok {
+		if addend != 0 {
+			return addend
+		}
+		// REL entry (no explicit addend): the value in the file IS the addend.
+		return val
+	}
+	return val
+}

--- a/macho.go
+++ b/macho.go
@@ -175,7 +175,8 @@ func (m *machoFile) getPCLNTABData() (uint64, []byte, error) {
 
 func (m *machoFile) moduledataSection() string {
 	// In Go 1.26, the moduledata was moved to its own section.
-	if section := m.file.Section("__DATA", "__go_module"); section != nil {
+	// Check Size > 0 because cgo binaries may have the section header but no data.
+	if section := m.file.Section("__DATA", "__go_module"); section != nil && section.Size > 0 {
 		return "__go_module"
 	}
 	return "__noptrdata"

--- a/moduledata.go
+++ b/moduledata.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"strconv"
 
+	"github.com/blacktop/go-macho"
 	"github.com/goretk/gore/extern"
 	"github.com/goretk/gore/extern/gover"
 )
@@ -276,6 +277,7 @@ func extractModuledata(f *GoFile) (moduledata, error) {
 	var off int
 	var magic []byte
 	var tabAddr uint64
+	var fromSymbol bool
 
 	secAddr, secData, err := f.fh.getSectionData(f.fh.moduledataSection())
 	if err != nil {
@@ -286,6 +288,7 @@ func extractModuledata(f *GoFile) (moduledata, error) {
 	sym, err := f.fh.getSymbol("runtime.firstmoduledata")
 	if err == nil {
 		off = int(sym.Value - secAddr)
+		fromSymbol = true
 		goto load
 	}
 
@@ -299,15 +302,36 @@ func extractModuledata(f *GoFile) (moduledata, error) {
 
 search:
 	off = bytes.Index(secData, magic)
+
+	if off == -1 {
+		if mf, ok := f.fh.getParsedFile().(*macho.File); ok && f.FileInfo.WordSize == 8 {
+			r := newMachoResolver(mf)
+			off = findPointerValue(r, secAddr, secData, tabAddr, f.FileInfo.WordSize, f.FileInfo.ByteOrder)
+		}
+	}
+
 load:
 	if off == -1 {
 		return moduledata{}, errors.New("could not find moduledata")
 	}
-	if len(secData) < off+vmdSize {
+
+	available := len(secData) - off
+	if available <= 0 {
 		return moduledata{}, fmt.Errorf("offset %d is out of bounds %d", off, len(secData))
 	}
 
-	data := secData[off : off+vmdSize]
+	var data []byte
+	if available >= vmdSize {
+		data = secData[off : off+vmdSize]
+	} else {
+		data = make([]byte, vmdSize)
+		copy(data, secData[off:])
+	}
+
+	if mf, ok := f.fh.getParsedFile().(*macho.File); ok && f.FileInfo.WordSize == 8 {
+		r := newMachoResolver(mf)
+		data = resolveBuffer(r, data, secAddr+uint64(off), f.FileInfo.WordSize, f.FileInfo.ByteOrder)
+	}
 
 	// Read the module struct from the file.
 	r := bytes.NewReader(data)
@@ -327,22 +351,19 @@ load:
 	if err != nil {
 		return moduledata{}, err
 	}
-	if text > etext {
-		goto invalidMD
-	}
 
-	if !(textSectAddr <= text && text < textSectAddr+uint64(len(textSect))) {
-		goto invalidMD
+	if text > etext || !(textSectAddr <= text && text < textSectAddr+uint64(len(textSect))) {
+		if fromSymbol {
+			return moduledata{}, fmt.Errorf("moduledata at symbol address failed text validation")
+		}
+		secData = secData[off+1:]
+		goto search
 	}
 
 	// Add the file handler.
 	md.fh = f.fh
 
 	return md, nil
-
-invalidMD:
-	secData = secData[off+1:]
-	goto search
 }
 
 func readUIntTo64(r io.Reader, byteOrder binary.ByteOrder, is32bit bool) (addr uint64, err error) {

--- a/type.go
+++ b/type.go
@@ -71,11 +71,13 @@ func getTypes(fileInfo *FileInfo, f fileHandler, md moduledata) (map[uint64]*GoT
 	}
 
 	// New parser
-	parser := newTypeParser(types, md.Types().Address, fileInfo)
+	typesAddr := md.Types().Address
+	resolver := newPointerResolver(f)
+	parser := newTypeParser(types, typesAddr, fileInfo, f, resolver)
 	for _, off := range typeLink {
-		typ, err := parser.parseType(uint64(off) + parser.base)
-		if err != nil || typ == nil {
-			return nil, fmt.Errorf("failed to parse type at offset 0x%x: %w", off, err)
+		_, err := parser.parseType(uint64(off) + typesAddr)
+		if err != nil {
+			continue
 		}
 	}
 	return parser.parsedTypes(), nil

--- a/type2.go
+++ b/type2.go
@@ -31,7 +31,7 @@ import (
 
 */
 
-func newTypeParser(typesData []byte, baseAddres uint64, fi *FileInfo) *typeParser {
+func newTypeParser(typesData []byte, baseAddres uint64, fi *FileInfo, fh fileHandler, resolver pointerResolver) *typeParser {
 	goversion := fi.goversion.Name
 
 	p := &typeParser{
@@ -42,6 +42,8 @@ func newTypeParser(typesData []byte, baseAddres uint64, fi *FileInfo) *typeParse
 		cache:     make(map[uint64]*GoType),
 		typesData: typesData,
 		r:         bytes.NewReader(typesData),
+		fh:        fh,
+		resolver:  resolver,
 	}
 
 	if fi.WordSize == 8 {
@@ -127,6 +129,9 @@ type typeParser struct {
 	// located.
 	typesData []byte
 
+	fh       fileHandler
+	resolver pointerResolver
+
 	goversion string
 
 	// Parse functions
@@ -147,12 +152,23 @@ type typeParser struct {
 }
 
 func (p *typeParser) hasTag(off uint64) bool {
+	if off >= uint64(len(p.typesData)) {
+		return false
+	}
 	return p.typesData[off]&(1<<1) != 0
 }
 
 func (p *typeParser) resolveName(ptr uint64, flags uint8) (string, int) {
+	if ptr+1 >= uint64(len(p.typesData)) {
+		return "", 0
+	}
 	i, l := p.parseNameLen(p, ptr+1)
-	name := string(p.typesData[ptr+1+uint64(l) : ptr+1+uint64(l)+i])
+	end := ptr + 1 + uint64(l) + i
+	start := ptr + 1 + uint64(l)
+	if end > uint64(len(p.typesData)) || start > end {
+		return "", 0
+	}
+	name := string(p.typesData[start:end])
 	nl := int(i)
 	if nl == 0 {
 		return "", 0
@@ -174,6 +190,9 @@ func (p *typeParser) resolveTag(o uint64) string {
 		return ""
 	}
 	o += 1 + nl + uint64(nll+tll)
+	if o+tl > uint64(len(p.typesData)) {
+		return ""
+	}
 	return string(p.typesData[o : o+tl])
 }
 
@@ -185,9 +204,35 @@ func (p *typeParser) readType(obj interface{}) (int, error) {
 	return binary.Size(obj), nil
 }
 
+func (p *typeParser) currentFileAddr() uint64 {
+	pos, _ := p.r.Seek(0, io.SeekCurrent)
+	return p.base + uint64(pos)
+}
+
 func (p *typeParser) seekFromStart(off uint64) error {
+	if off > uint64(len(p.typesData)) {
+		return fmt.Errorf("seek offset 0x%x exceeds data length 0x%x", off, len(p.typesData))
+	}
 	_, err := p.r.Seek(int64(off), io.SeekStart)
 	return err
+}
+
+func (p *typeParser) switchToSection(addr uint64) func() {
+	if addr >= p.base && addr-p.base < uint64(len(p.typesData)) {
+		return nil
+	}
+	if p.fh == nil {
+		return nil
+	}
+	sectionBase, sectionData, err := p.fh.getSectionDataFromAddress(addr)
+	if err != nil {
+		return nil
+	}
+	oldBase, oldData, oldReader := p.base, p.typesData, p.r
+	p.base, p.typesData, p.r = sectionBase, sectionData, bytes.NewReader(sectionData)
+	return func() {
+		p.base, p.typesData, p.r = oldBase, oldData, oldReader
+	}
 }
 
 // parsedTypes returns all the parsed types for the file. This method
@@ -205,6 +250,10 @@ func (p *typeParser) parseType(address uint64) (*GoType, error) {
 	// First check the cache.
 	if t, ok := p.cache[address]; ok {
 		return t, nil
+	}
+
+	if restore := p.switchToSection(address); restore != nil {
+		defer restore()
 	}
 
 	/*
@@ -301,7 +350,10 @@ func (p *typeParser) parseType(address uint64) (*GoType, error) {
 
 		if iface.MethodsLen > 0 {
 			child = iface.Methods
-			typ.Methods = make([]*TypeMethod, int(iface.MethodsLen), int(iface.MethodsCap))
+			if iface.MethodsLen > 1<<20 {
+				return nil, fmt.Errorf("interface at 0x%x has unreasonable method count %d", address, iface.MethodsLen)
+			}
+			typ.Methods = make([]*TypeMethod, int(iface.MethodsLen))
 		}
 
 	case reflect.Map:
@@ -319,6 +371,7 @@ func (p *typeParser) parseType(address uint64) (*GoType, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse pointer to type for type located at 0x%x: %w", address, err)
 		}
+		ptr = resolvePointer(p.resolver,ptr, address+uint64(count))
 		count += c
 
 		child = ptr
@@ -335,7 +388,10 @@ func (p *typeParser) parseType(address uint64) (*GoType, error) {
 		count += c
 
 		child = s.FieldsData
-		typ.Fields = make([]*GoType, int(s.FieldsLen), int(s.FieldsCap))
+		if s.FieldsLen > 1<<20 {
+			return nil, fmt.Errorf("struct at 0x%x has unreasonable field count %d", address, s.FieldsLen)
+		}
+		typ.Fields = make([]*GoType, int(s.FieldsLen))
 
 		// Resolve package path.
 		if s.PkgPath > uint64(p.base) {
@@ -509,6 +565,7 @@ func (p *typeParser) parseType(address uint64) (*GoType, error) {
 				if err != nil {
 					return nil, fmt.Errorf("failed to read function argument/return type pointer at 0x%x: %w", child+uint64(n), err)
 				}
+				ptr = resolvePointer(p.resolver,ptr, child+n)
 				n += uint64(c)
 
 				// Parse the type for the function argument.
@@ -600,7 +657,10 @@ func (p *typeParser) parseType(address uint64) (*GoType, error) {
 				// embedded struct field was moved from the offset field to the name field. This changed was first part of the
 				// 1.19rc1 release.s
 				if GoVersionCompare(p.goversion, "go1.19rc1") >= 0 {
-					field.FieldAnon = p.typesData[sf.Name-p.base]&(1<<3) != 0
+					nameOff := sf.Name - p.base
+					if nameOff < uint64(len(p.typesData)) {
+						field.FieldAnon = p.typesData[nameOff]&(1<<3) != 0
+					}
 				} else {
 					field.FieldAnon = name == "" || sf.OffsetEmbed&1 != 0
 				}
@@ -625,8 +685,14 @@ func (p *typeParser) parseType(address uint64) (*GoType, error) {
 type arrayTypeParseFunc func(p *typeParser) (arrayType64, int, error)
 
 var arrayTypeParseFunc64 = func(p *typeParser) (arrayType64, int, error) {
+	fileAddr := p.currentFileAddr()
 	var typ arrayType64
 	c, err := p.readType(&typ)
+	if err != nil {
+		return typ, c, err
+	}
+	typ.Eem = resolvePointer(p.resolver,typ.Eem, fileAddr)
+	typ.Slice = resolvePointer(p.resolver,typ.Slice, fileAddr+8)
 	return typ, c, err
 }
 
@@ -649,8 +715,13 @@ var arrayTypeParseFunc32 = func(p *typeParser) (arrayType64, int, error) {
 type chanTypeParseFunc func(p *typeParser) (chanType, int, error)
 
 var chanTypeParseFunc64 = func(p *typeParser) (chanType, int, error) {
+	fileAddr := p.currentFileAddr()
 	var typ chanType
 	c, err := p.readType(&typ)
+	if err != nil {
+		return typ, c, err
+	}
+	typ.Elem = resolvePointer(p.resolver,typ.Elem, fileAddr)
 	return typ, c, err
 }
 
@@ -712,8 +783,14 @@ var imethodTypeParseFunc64 = func(p *typeParser) (imethod, int, error) {
 type interfaceTypeParseFunc func(p *typeParser) (interfaceType, int, error)
 
 var interfaceTypeParseFunc64 = func(p *typeParser) (interfaceType, int, error) {
+	fileAddr := p.currentFileAddr()
 	var typ interfaceType
 	c, err := p.readType(&typ)
+	if err != nil {
+		return typ, c, err
+	}
+	typ.PkgPath = resolvePointer(p.resolver,typ.PkgPath, fileAddr)
+	typ.Methods = resolvePointer(p.resolver,typ.Methods, fileAddr+8)
 	return typ, c, err
 }
 
@@ -737,8 +814,16 @@ var interfaceTypeParseFunc32 = func(p *typeParser) (interfaceType, int, error) {
 type mapTypeParseFunc func(p *typeParser) (mapType, int, error)
 
 var mapTypeParseFunc64 = func(p *typeParser) (mapType, int, error) {
+	fileAddr := p.currentFileAddr()
 	var typ mapType
 	c, err := p.readType(&typ)
+	if err != nil {
+		return typ, c, err
+	}
+	typ.Key = resolvePointer(p.resolver,typ.Key, fileAddr)
+	typ.Elem = resolvePointer(p.resolver,typ.Elem, fileAddr+8)
+	typ.Bucket = resolvePointer(p.resolver,typ.Bucket, fileAddr+16)
+	typ.Hasher = resolvePointer(p.resolver,typ.Hasher, fileAddr+24)
 	return typ, c, err
 }
 
@@ -763,6 +848,7 @@ var mapTypeParseFunc32 = func(p *typeParser) (mapType, int, error) {
 
 // Map parser for Go 1.7 to 1.10 (64 bit)
 var mapTypeParseFunc1764 = func(p *typeParser) (mapType, int, error) {
+	fileAddr := p.currentFileAddr()
 	var typ mapTypeGo1764
 	c, err := p.readType(&typ)
 	if err != nil {
@@ -770,9 +856,9 @@ var mapTypeParseFunc1764 = func(p *typeParser) (mapType, int, error) {
 	}
 
 	return mapType{
-		Key:        typ.Key,
-		Elem:       typ.Elem,
-		Bucket:     typ.Bucket,
+		Key:        resolvePointer(p.resolver,typ.Key, fileAddr),
+		Elem:       resolvePointer(p.resolver,typ.Elem, fileAddr+8),
+		Bucket:     resolvePointer(p.resolver,typ.Bucket, fileAddr+16),
 		Keysize:    typ.Keysize,
 		Valuesize:  typ.Valuesize,
 		Bucketsize: typ.Bucketsize,
@@ -799,6 +885,7 @@ var mapTypeParseFunc1732 = func(p *typeParser) (mapType, int, error) {
 
 // Map parser for Go 1.11 (64 bit)
 var mapTypeParseFunc1164 = func(p *typeParser) (mapType, int, error) {
+	fileAddr := p.currentFileAddr()
 	var typ mapTypeGo1164
 	c, err := p.readType(&typ)
 	if err != nil {
@@ -806,9 +893,9 @@ var mapTypeParseFunc1164 = func(p *typeParser) (mapType, int, error) {
 	}
 
 	return mapType{
-		Key:        typ.Key,
-		Elem:       typ.Elem,
-		Bucket:     typ.Bucket,
+		Key:        resolvePointer(p.resolver,typ.Key, fileAddr),
+		Elem:       resolvePointer(p.resolver,typ.Elem, fileAddr+8),
+		Bucket:     resolvePointer(p.resolver,typ.Bucket, fileAddr+16),
 		Keysize:    typ.Keysize,
 		Valuesize:  typ.Valuesize,
 		Bucketsize: typ.Bucketsize,
@@ -835,6 +922,7 @@ var mapTypeParseFunc1132 = func(p *typeParser) (mapType, int, error) {
 
 // Map parser for Go 1.12 and 1.13 (64 bit)
 var mapTypeParseFunc1264 = func(p *typeParser) (mapType, int, error) {
+	fileAddr := p.currentFileAddr()
 	var typ mapTypeGo1264
 	c, err := p.readType(&typ)
 	if err != nil {
@@ -842,9 +930,9 @@ var mapTypeParseFunc1264 = func(p *typeParser) (mapType, int, error) {
 	}
 
 	return mapType{
-		Key:        typ.Key,
-		Elem:       typ.Elem,
-		Bucket:     typ.Bucket,
+		Key:        resolvePointer(p.resolver,typ.Key, fileAddr),
+		Elem:       resolvePointer(p.resolver,typ.Elem, fileAddr+8),
+		Bucket:     resolvePointer(p.resolver,typ.Bucket, fileAddr+16),
 		Keysize:    typ.Keysize,
 		Valuesize:  typ.Valuesize,
 		Bucketsize: typ.Bucketsize,
@@ -920,8 +1008,14 @@ var rtypeParseFunc32 = func(p *typeParser) (rtypeGo64, int, error) {
 type structTypeParseFunc func(p *typeParser) (structType64, int, error)
 
 var structTypeParseFunc64 = func(p *typeParser) (structType64, int, error) {
+	fileAddr := p.currentFileAddr()
 	var typ structType64
 	c, err := p.readType(&typ)
+	if err != nil {
+		return typ, c, err
+	}
+	typ.PkgPath = resolvePointer(p.resolver,typ.PkgPath, fileAddr)
+	typ.FieldsData = resolvePointer(p.resolver,typ.FieldsData, fileAddr+8)
 	return typ, c, err
 }
 
@@ -945,8 +1039,14 @@ var structTypeParseFunc32 = func(p *typeParser) (structType64, int, error) {
 type structFieldTypeParseFunc func(p *typeParser) (structField, int, error)
 
 var structFieldTypeParseFunc64 = func(p *typeParser) (structField, int, error) {
+	fileAddr := p.currentFileAddr()
 	var typ structField
 	c, err := p.readType(&typ)
+	if err != nil {
+		return typ, c, err
+	}
+	typ.Name = resolvePointer(p.resolver,typ.Name, fileAddr)
+	typ.Typ = resolvePointer(p.resolver,typ.Typ, fileAddr+8)
 	return typ, c, err
 }
 
@@ -1004,10 +1104,16 @@ var uncommonTypeParseFunc17Beta1 = func(p *typeParser) (uncommonType, int, error
 type nameLenParseFunc func(p *typeParser, offset uint64) (uint64, int)
 
 var nameLenParseFuncTwoByteFixed = func(p *typeParser, offset uint64) (uint64, int) {
+	if offset+1 >= uint64(len(p.typesData)) {
+		return 0, 0
+	}
 	return uint64(uint16(p.typesData[offset])<<8 | uint16(p.typesData[offset+1])), 2
 }
 
 var nameLenParseFuncVarint = func(p *typeParser, offset uint64) (uint64, int) {
+	if offset >= uint64(len(p.typesData)) {
+		return 0, 0
+	}
 	return binary.Uvarint(p.typesData[offset:])
 }
 


### PR DESCRIPTION
type parsed failed on

https://github.com/Zxilly/go-testdata/releases/download/latest/bin-darwin-1.26-arm64-strip-pie-cgo
https://github.com/Zxilly/go-testdata/releases/download/latest/bin-darwin-1.26-amd64-pie-cgo
https://github.com/Zxilly/go-testdata/releases/download/latest/bin-linux-1.26-arm64-pie-cgo
https://github.com/Zxilly/go-testdata/releases/download/latest/bin-linux-1.26-386-cgo