### PR TITLE
Readd go generate command for versions

### DIFF
--- a/goversion.go
+++ b/goversion.go
@@ -2,6 +2,9 @@
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
+//go:generate go run ./gen goversion
+
 package gore
 
 import (


### PR DESCRIPTION
The go generate line was accidentally removed when the copyright header was switched.
This adds the line back again.